### PR TITLE
feat: add blockchair and update get balance method to accept multiple address

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/bitcoin.git"
   },
   "source": {
-    "shasum": "QYsZ8HVb8OmMmPlePs8t9NbV0CIZkt7KucFBw/CkEuQ=",
+    "shasum": "SeWMmXKfuQ7q4TZScQ1ANgp9ssppSHYNzR2csvh9SpU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -6,8 +6,7 @@ import type {
   SnapRpcRequestHandlerRequest,
   IStaticSnapRpcRequestHandler,
 } from './rpcs';
-import { CreateAccountHandler } from './rpcs';
-import { GetBalanceHandler } from './rpcs/methods/get-balance';
+import { CreateAccountHandler, GetBalancesHandler } from './rpcs';
 
 const validateOrigin = async (origin: string) => {
   // TODO: validate origin
@@ -20,8 +19,8 @@ const getHandler = (method: string): IStaticSnapRpcRequestHandler => {
   switch (method) {
     case 'bitcoin_createAccount':
       return CreateAccountHandler;
-    case 'bitcoin_getBalance':
-      return GetBalanceHandler;
+    case 'bitcoin_getBalances':
+      return GetBalancesHandler;
     default:
       throw new SnapError(`Method not found`);
   }

--- a/packages/snap/src/modules/async/helpers.test.ts
+++ b/packages/snap/src/modules/async/helpers.test.ts
@@ -1,0 +1,15 @@
+import { expect, jest } from '@jest/globals';
+
+import { AsyncHelper } from './helpers';
+
+describe('AsyncHelper', function () {
+  describe('processBatch', function () {
+    it('processes the array in batch', async function () {
+      const fn = jest.fn() as any;
+      const mockArr = new Array(99).fill(0);
+
+      await AsyncHelper.processBatch<number>(mockArr, fn);
+      expect(fn).toHaveBeenCalledTimes(mockArr.length);
+    });
+  });
+});

--- a/packages/snap/src/modules/async/helpers.ts
+++ b/packages/snap/src/modules/async/helpers.ts
@@ -1,0 +1,19 @@
+export class AsyncHelper {
+  static async processBatch<Data>(
+    arr: Data[],
+    callback: (item: Data) => Promise<void>,
+    batchSize = 50,
+  ): Promise<void> {
+    let from = 0;
+    let to = batchSize;
+    while (from < arr.length) {
+      const batch: Promise<void>[] = [];
+      for (let i = from; i < Math.min(to, arr.length); i++) {
+        batch.push(callback(arr[i]));
+      }
+      await Promise.all(batch);
+      from += batchSize;
+      to += batchSize;
+    }
+  }
+}

--- a/packages/snap/src/modules/async/index.ts
+++ b/packages/snap/src/modules/async/index.ts
@@ -1,0 +1,1 @@
+export * from './helpers';

--- a/packages/snap/src/modules/bitcoin/config/constants.ts
+++ b/packages/snap/src/modules/bitcoin/config/constants.ts
@@ -1,9 +1,14 @@
 export enum Network {
-  Mainnet = '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f',
-  Testnet = '000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943',
+  Mainnet = 'bip122:000000000019d6689c085ae165831e93',
+  Testnet = 'bip122:000000000933ea01ad0ee984209779ba',
 }
 
 export enum DataClient {
   BlockStream = 'BlockStream',
   BlockChair = 'BlockChair',
+}
+
+export enum BtcAsset {
+  Btc = 'bip122:000000000019d6689c085ae165831e93:slip44:0',
+  TBtc = 'bip122:000000000933ea01ad0ee984209779ba:slip44:0',
 }

--- a/packages/snap/src/modules/bitcoin/data-client/clients/blockchair.test.ts
+++ b/packages/snap/src/modules/bitcoin/data-client/clients/blockchair.test.ts
@@ -1,0 +1,131 @@
+import { networks } from 'bitcoinjs-lib';
+
+import {
+  generateAccounts,
+  generateBlockChairGetBalanceResp,
+} from '../../../../../test/utils';
+import { DataClientError } from '../exceptions';
+import { BlockChairClient } from './blockchair';
+
+jest.mock('../../../logger/logger', () => ({
+  logger: {
+    info: jest.fn(),
+  },
+}));
+
+describe('BlockChairClient', () => {
+  const createMockFetch = () => {
+    // eslint-disable-next-line no-restricted-globals
+    Object.defineProperty(global, 'fetch', {
+      writable: true,
+    });
+
+    const fetchSpy = jest.fn();
+    // eslint-disable-next-line no-restricted-globals
+    global.fetch = fetchSpy;
+
+    return {
+      fetchSpy,
+    };
+  };
+
+  describe('baseUrl', () => {
+    it('returns testnet network url', () => {
+      const instance = new BlockChairClient({ network: networks.testnet });
+      expect(instance.baseUrl).toBe(
+        'https://api.blockchair.com/bitcoin/testnet',
+      );
+    });
+
+    it('returns mainnet network url', () => {
+      const instance = new BlockChairClient({ network: networks.bitcoin });
+      expect(instance.baseUrl).toBe('https://api.blockchair.com/bitcoin');
+    });
+
+    it('throws `Invalid network` error if the given network is not support', () => {
+      const instance = new BlockChairClient({ network: networks.regtest });
+      expect(() => instance.baseUrl).toThrow('Invalid network');
+    });
+  });
+
+  describe('getBalances', () => {
+    it('returns balances', async () => {
+      const { fetchSpy } = createMockFetch();
+      const accounts = generateAccounts(10);
+      const addresses = accounts.map((account) => account.address);
+      const mockResponse = generateBlockChairGetBalanceResp(addresses);
+      const expectedResult = mockResponse.data;
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const instance = new BlockChairClient({ network: networks.testnet });
+      const result = await instance.getBalances(addresses);
+
+      expect(result).toStrictEqual(expectedResult);
+    });
+
+    it('assigns balance to 0 if account is not exist', async () => {
+      const { fetchSpy } = createMockFetch();
+      const accounts = generateAccounts(2);
+      const accountWithNoBalance = generateAccounts(1, 'notexist')[0];
+      const addresses = accounts.map((account) => account.address);
+      const mockResponse = generateBlockChairGetBalanceResp(addresses);
+
+      const expectedResult = {
+        ...mockResponse.data,
+        [accountWithNoBalance.address]: 0,
+      };
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const instance = new BlockChairClient({ network: networks.testnet });
+      const result = await instance.getBalances(
+        addresses.concat(accountWithNoBalance.address),
+      );
+
+      expect(result).toStrictEqual(expectedResult);
+    });
+
+    it('throws DataClientError error if an non DataClientError catched', async () => {
+      const { fetchSpy } = createMockFetch();
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockRejectedValue(new Error('error')),
+      });
+
+      const accounts = generateAccounts(1);
+      const addresses = accounts.map((account) => account.address);
+
+      const instance = new BlockChairClient({ network: networks.testnet });
+
+      await expect(instance.getBalances(addresses)).rejects.toThrow(
+        DataClientError,
+      );
+    });
+
+    it('throws DataClientError error if an DataClientError catched', async () => {
+      const { fetchSpy } = createMockFetch();
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: false,
+        json: jest.fn().mockResolvedValue(null),
+      });
+
+      const accounts = generateAccounts(1);
+      const addresses = accounts.map((account) => account.address);
+
+      const instance = new BlockChairClient({ network: networks.testnet });
+
+      await expect(instance.getBalances(addresses)).rejects.toThrow(
+        DataClientError,
+      );
+    });
+  });
+});

--- a/packages/snap/src/modules/bitcoin/data-client/clients/blockchair.ts
+++ b/packages/snap/src/modules/bitcoin/data-client/clients/blockchair.ts
@@ -1,0 +1,98 @@
+import { type Network, networks } from 'bitcoinjs-lib';
+
+import { logger } from '../../../logger/logger';
+import { type Balances } from '../../../transaction';
+import { DataClientError } from '../exceptions';
+import type { IReadDataClient } from '../types';
+
+export type BlockChairClientOptions = {
+  network: Network;
+};
+
+/* eslint-disable */
+export type GetBalanceResponse = {
+  data: {
+    [address: string]: number;
+  };
+  context: {
+    code: number;
+    source: string;
+    results: number;
+    state: number;
+    market_price_usd: number;
+    cache: {
+      live: boolean;
+      duration: number;
+      since: string;
+      until: string;
+      time: null;
+    };
+    api: {
+      version: string;
+      last_major_update: string;
+      next_major_update: string;
+      documentation: string;
+      notice: string;
+    };
+    servers: string;
+    time: number;
+    render_time: number;
+    full_time: number;
+    request_cost: number;
+  };
+};
+/* eslint-disable */
+
+export class BlockChairClient implements IReadDataClient {
+  options: BlockChairClientOptions;
+
+  constructor(options: BlockChairClientOptions) {
+    this.options = options;
+  }
+
+  get baseUrl(): string {
+    switch (this.options.network) {
+      case networks.bitcoin:
+        return 'https://api.blockchair.com/bitcoin';
+      case networks.testnet:
+        return 'https://api.blockchair.com/bitcoin/testnet';
+      default:
+        throw new DataClientError('Invalid network');
+    }
+  }
+
+  protected async get<Resp>(endpoint: string): Promise<Resp> {
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      method: 'GET',
+    });
+
+    if (!response.ok) {
+      throw new DataClientError(
+        `Failed to fetch data from blockchair: ${response.statusText}`,
+      );
+    }
+    return response.json() as unknown as Resp;
+  }
+
+  async getBalances(addresses: string[]): Promise<Balances> {
+    try {
+      const response = await this.get<GetBalanceResponse>(
+        `/addresses/balances?addresses=${addresses.join(',')}`,
+      );
+
+      logger.info(
+        `[BlockChairClient.getBalance] response: ${JSON.stringify(response)}`,
+      );
+
+      return addresses.reduce((data: Balances, address: string) => {
+        data[address] = response.data[address] ?? 0;
+        return data;
+      }, {});
+    } catch (error) {
+      if (error instanceof DataClientError) {
+        throw error;
+      }
+      throw new DataClientError(error);
+    }
+  }
+}

--- a/packages/snap/src/modules/bitcoin/data-client/factory.test.ts
+++ b/packages/snap/src/modules/bitcoin/data-client/factory.test.ts
@@ -1,6 +1,7 @@
 import { networks } from 'bitcoinjs-lib';
 
 import { DataClient } from '../config';
+import { BlockChairClient } from './clients/blockchair';
 import { BlockStreamClient } from './clients/blockstream';
 import { DataClientFactory } from './factory';
 
@@ -15,13 +16,26 @@ describe('DataClientFactory', () => {
       expect(instance).toBeInstanceOf(BlockStreamClient);
     });
 
+    it('creates BlockChairClient', () => {
+      const instance = DataClientFactory.createReadClient(
+        { dataClient: { read: { type: DataClient.BlockChair } } },
+        networks.testnet,
+      );
+
+      expect(instance).toBeInstanceOf(BlockChairClient);
+    });
+
     it('throws `Unsupported client type` if the given client is not support', () => {
       expect(() =>
         DataClientFactory.createReadClient(
-          { dataClient: { read: { type: DataClient.BlockChair } } },
+          {
+            dataClient: {
+              read: { type: 'SomeClient' as unknown as DataClient },
+            },
+          },
           networks.testnet,
         ),
-      ).toThrow('Unsupported client type: BlockChair');
+      ).toThrow('Unsupported client type: SomeClient');
     });
   });
 });

--- a/packages/snap/src/modules/bitcoin/data-client/factory.ts
+++ b/packages/snap/src/modules/bitcoin/data-client/factory.ts
@@ -1,6 +1,7 @@
 import { type Network } from 'bitcoinjs-lib';
 
 import { DataClient, type BtcTransactionConfig } from '../config';
+import { BlockChairClient } from './clients/blockchair';
 import { BlockStreamClient } from './clients/blockstream';
 import { DataClientError } from './exceptions';
 import type { IReadDataClient } from './types';
@@ -13,8 +14,11 @@ export class DataClientFactory {
     switch (config.dataClient.read.type) {
       case DataClient.BlockStream:
         return new BlockStreamClient({ network });
+      case DataClient.BlockChair:
+        return new BlockChairClient({ network });
       default:
         throw new DataClientError(
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `Unsupported client type: ${config.dataClient.read.type}`,
         );
     }

--- a/packages/snap/src/modules/bitcoin/data-client/types.ts
+++ b/packages/snap/src/modules/bitcoin/data-client/types.ts
@@ -1,7 +1,7 @@
-import { type Balance } from '../../transaction';
+import { type Balances } from '../../transaction';
 
 export type IReadDataClient = {
-  getBalance(address: string): Promise<Balance>;
+  getBalances(address: string[]): Promise<Balances>;
 };
 
 export type IWriteDataClient = {

--- a/packages/snap/src/modules/bitcoin/transaction/manager.ts
+++ b/packages/snap/src/modules/bitcoin/transaction/manager.ts
@@ -1,4 +1,12 @@
-import type { ITransactionMgr, Balance } from '../../transaction/types';
+import type { Network } from 'bitcoinjs-lib';
+import { networks } from 'bitcoinjs-lib';
+
+import type {
+  ITransactionMgr,
+  Balances,
+  AssetBalances,
+} from '../../transaction/types';
+import { BtcAsset } from '../config';
 import { type IReadDataClient } from '../data-client';
 import { TransactionMgrError } from './exceptions';
 import type { BtcTransactionMgrOptions } from './types';
@@ -13,10 +21,44 @@ export class BtcTransactionMgr implements ITransactionMgr {
     this.options = options;
   }
 
-  async getBalance(address: string): Promise<Balance> {
+  get network(): Network {
+    return this.options.network;
+  }
+
+  async getBalances(
+    addresses: string[],
+    assets: string[],
+  ): Promise<AssetBalances> {
     try {
-      const response = await this.readClient.getBalance(address);
-      return response;
+      if (assets.length > 1) {
+        throw new TransactionMgrError('Only one asset is supported');
+      }
+
+      const allowedAssets = new Set<string>(
+        Object.entries(BtcAsset).map(([_, value]) => value.toString()),
+      );
+
+      if (
+        !allowedAssets.has(assets[0]) ||
+        (this.network === networks.testnet && assets[0] !== BtcAsset.TBtc) ||
+        (this.network === networks.bitcoin && assets[0] !== BtcAsset.Btc)
+      ) {
+        throw new TransactionMgrError('Invalid asset');
+      }
+
+      const balance: Balances = await this.readClient.getBalances(addresses);
+
+      return addresses.reduce<AssetBalances>(
+        (acc: AssetBalances, address: string) => {
+          acc.balances[address] = {
+            [assets[0]]: {
+              amount: balance[address],
+            },
+          };
+          return acc;
+        },
+        { balances: {} },
+      );
     } catch (error) {
       throw new TransactionMgrError(error);
     }

--- a/packages/snap/src/modules/config/index.ts
+++ b/packages/snap/src/modules/config/index.ts
@@ -34,7 +34,7 @@ export const Config: SnapConfig = {
     [Chain.Bitcoin]: {
       dataClient: {
         read: {
-          type: DataClient.BlockStream,
+          type: DataClient.BlockChair,
         },
       },
     },

--- a/packages/snap/src/modules/transaction/transaction.test.ts
+++ b/packages/snap/src/modules/transaction/transaction.test.ts
@@ -1,4 +1,5 @@
 import { generateAccounts } from '../../../test/utils';
+import { BtcAsset } from '../bitcoin/config';
 import { TransactionServiceError } from './exceptions';
 import { TransactionStateManager } from './state';
 import { TransactionService } from './transaction';
@@ -6,44 +7,46 @@ import type { ITransactionMgr } from './types';
 
 describe('TransactionService', () => {
   const createMockTxnMgr = () => {
-    const getBalanceSpy = jest.fn();
+    const getBalancesSpy = jest.fn();
 
     class MockTxnMgr implements ITransactionMgr {
-      getBalance = getBalanceSpy;
+      getBalances = getBalancesSpy;
     }
     return {
       instance: new MockTxnMgr(),
-      getBalanceSpy,
+      getBalancesSpy,
     };
   };
 
   describe('getBalance', () => {
-    it('calls getBalance with transactionMgr', async () => {
-      const { instance, getBalanceSpy } = createMockTxnMgr();
+    it('calls getBalances with transactionMgr', async () => {
+      const { instance, getBalancesSpy } = createMockTxnMgr();
       const accounts = generateAccounts(1);
+      const addresses = accounts.map((account) => account.address);
 
       const service = new TransactionService(
         instance,
         new TransactionStateManager(),
       );
-      await service.getBalance(accounts[0].address);
+      await service.getBalances(addresses, [BtcAsset.TBtc]);
 
-      expect(getBalanceSpy).toHaveBeenCalledWith(accounts[0].address);
+      expect(getBalancesSpy).toHaveBeenCalledWith(addresses, [BtcAsset.TBtc]);
     });
 
-    it('throws TransactionServiceError if getBalance failed', async () => {
-      const { instance, getBalanceSpy } = createMockTxnMgr();
-      getBalanceSpy.mockRejectedValue(new Error('error'));
+    it('throws TransactionServiceError if getBalances failed', async () => {
+      const { instance, getBalancesSpy } = createMockTxnMgr();
+      getBalancesSpy.mockRejectedValue(new Error('error'));
       const accounts = generateAccounts(1);
+      const addresses = accounts.map((account) => account.address);
 
       const service = new TransactionService(
         instance,
         new TransactionStateManager(),
       );
 
-      await expect(service.getBalance(accounts[0].address)).rejects.toThrow(
-        TransactionServiceError,
-      );
+      await expect(
+        service.getBalances(addresses, [BtcAsset.TBtc]),
+      ).rejects.toThrow(TransactionServiceError);
     });
   });
 });

--- a/packages/snap/src/modules/transaction/transaction.ts
+++ b/packages/snap/src/modules/transaction/transaction.ts
@@ -1,6 +1,6 @@
 import { TransactionServiceError } from './exceptions';
 import type { TransactionStateManager } from './state';
-import type { Balance, ITransactionMgr } from './types';
+import type { AssetBalances, ITransactionMgr } from './types';
 
 export class TransactionService {
   protected readonly transactionMgr: ITransactionMgr;
@@ -15,9 +15,12 @@ export class TransactionService {
     this.transactionStateManager = transactionStateManager;
   }
 
-  async getBalance(address: string): Promise<Balance> {
+  async getBalances(
+    addresses: string[],
+    assets: string[],
+  ): Promise<AssetBalances> {
     try {
-      const result = await this.transactionMgr.getBalance(address);
+      const result = await this.transactionMgr.getBalances(addresses, assets);
       return result;
     } catch (error) {
       throw new TransactionServiceError(error);

--- a/packages/snap/src/modules/transaction/types.ts
+++ b/packages/snap/src/modules/transaction/types.ts
@@ -1,9 +1,17 @@
+export type Balances = Record<string, number>;
+
 export type Balance = {
-  confirmed: number;
-  unconfirmed: number;
-  total: number;
+  amount: number;
+};
+
+export type AssetBalances = {
+  balances: {
+    [address: string]: {
+      [asset: string]: Balance;
+    };
+  };
 };
 
 export type ITransactionMgr = {
-  getBalance(address: string): Promise<Balance>;
+  getBalances(addresses: string[], assets: string[]): Promise<AssetBalances>;
 };

--- a/packages/snap/src/rpcs/index.ts
+++ b/packages/snap/src/rpcs/index.ts
@@ -1,4 +1,5 @@
 export * from './methods/create-account';
+export * from './methods/get-balances';
 export * from './types';
 export * from './base';
 export * from './exceptions';

--- a/packages/snap/src/rpcs/methods/get-balances.ts
+++ b/packages/snap/src/rpcs/methods/get-balances.ts
@@ -1,9 +1,9 @@
 import type { Infer } from 'superstruct';
-import { object, string, assign } from 'superstruct';
+import { object, string, assign, array } from 'superstruct';
 
 import { Chain } from '../../modules/config';
 import { Factory } from '../../modules/factory';
-import type { Balance } from '../../modules/transaction';
+import type { AssetBalances } from '../../modules/transaction';
 import {
   TransactionService,
   TransactionStateManager,
@@ -16,34 +16,35 @@ import type {
 } from '../types';
 import { SnapRpcRequestHandlerRequestStruct } from '../types';
 
-export type GetBalanceParams = Infer<typeof GetBalanceHandler.validateStruct>;
+export type GetBalancesParams = Infer<typeof GetBalancesHandler.validateStruct>;
 
-export type GetBalanceResponse = SnapRpcRequestHandlerResponse & Balance;
+export type GetBalancesResponse = SnapRpcRequestHandlerResponse & AssetBalances;
 
-export class GetBalanceHandler
+export class GetBalancesHandler
   extends BaseSnapRpcRequestHandler
   implements
-    StaticImplements<IStaticSnapRpcRequestHandler, typeof GetBalanceHandler>
+    StaticImplements<IStaticSnapRpcRequestHandler, typeof GetBalancesHandler>
 {
   static get validateStruct() {
     return assign(
       object({
-        address: string(),
+        accounts: array(string()),
+        assets: array(string()),
       }),
       SnapRpcRequestHandlerRequestStruct,
     );
   }
 
-  validateStruct = GetBalanceHandler.validateStruct;
+  validateStruct = GetBalancesHandler.validateStruct;
 
-  async handleRequest(params: GetBalanceParams): Promise<GetBalanceResponse> {
-    const { scope, address } = params;
+  async handleRequest(params: GetBalancesParams): Promise<GetBalancesResponse> {
+    const { scope, accounts, assets } = params;
 
     const txService = new TransactionService(
       Factory.createTransactionMgr(Chain.Bitcoin, scope),
       new TransactionStateManager(),
     );
 
-    return await txService.getBalance(address);
+    return await txService.getBalances(accounts, assets);
   }
 }

--- a/packages/snap/test/fixtures/blockchair.json
+++ b/packages/snap/test/fixtures/blockchair.json
@@ -1,0 +1,31 @@
+{
+  "getBalanceResp": {
+    "data": {},
+    "context": {
+      "code": 200,
+      "source": "A",
+      "results": 2,
+      "state": 2587556,
+      "market_price_usd": 62471,
+      "cache": {
+        "live": true,
+        "duration": 20,
+        "since": "2024-04-19 01:15:47",
+        "until": "2024-04-19 01:16:07",
+        "time": null
+      },
+      "api": {
+        "version": "2.0.95-ie",
+        "last_major_update": "2022-11-07 02:00:00",
+        "next_major_update": "2023-11-12 02:00:00",
+        "documentation": "https://blockchair.com/api/docs",
+        "notice": "Plaese note that on November 12th, 2023 public support for the following blockchains will be dropped: Mixin, Ethereum Testnet (Goerli)"
+      },
+      "servers": "API4,TBTC3",
+      "time": 0.4156050682067871,
+      "render_time": 0.0018379688262939453,
+      "full_time": 0.41744303703308105,
+      "request_cost": 1.003
+    }
+  }
+}

--- a/packages/snap/test/fixtures/blockstream.json
+++ b/packages/snap/test/fixtures/blockstream.json
@@ -1,5 +1,5 @@
 {
-  "accountInfo": {
+  "getAccountStatsResp": {
     "address": "tb1qt2mpt38wmgw3j0hnr9mp5hsa7kxf2a3ktdxaeu",
     "chain_stats": {
       "funded_txo_count": 12,

--- a/packages/snap/test/utils.ts
+++ b/packages/snap/test/utils.ts
@@ -2,6 +2,9 @@ import type { BIP32Interface } from 'bip32';
 import type { Network } from 'bitcoinjs-lib';
 import { Buffer } from 'buffer';
 
+import blockChairData from './fixtures/blockchair.json';
+import blockStreamData from './fixtures/blockstream.json';
+
 /**
  * Method to generate testing account.
  *
@@ -45,9 +48,9 @@ export function generateAccounts(cnt = 1, addressPrefix = '', idPrefix = '') {
  * @param network - Bitcoin network.
  * @param idx - Index of the bip32 instance.
  * @param depth - Depth of the bip32 instance.
- * @returns An BIP32Interface instance.
+ * @returns An BIP32Interface instance and spys.
  */
-export const createMockBip32Instance = (
+export function createMockBip32Instance(
   network: Network,
   idx = 0,
   depth = 0,
@@ -63,7 +66,7 @@ export const createMockBip32Instance = (
   tweakSpy: jest.Mock;
   signSpy: jest.Mock;
   verifySpy: jest.Mock;
-} => {
+} {
   const deriveHardenedSpy = jest.fn();
   const deriveSpy = jest.fn();
   const derivePathSpy = jest.fn();
@@ -142,4 +145,54 @@ export const createMockBip32Instance = (
     signSpy,
     verifySpy,
   };
-};
+}
+
+const randomNum = (max) => Math.floor(Math.random() * max);
+/**
+ * Method to generate blockstream account stats resp by addresses.
+ *
+ * @param addresses - Array of address in string.
+ * @returns An array of blocksteam stats response.
+ */
+export function generateBlockStreamAccountStats(addresses: string[]) {
+  const template = blockStreamData.getAccountStatsResp;
+  const resp: (typeof template)[] = [];
+  for (const address of addresses) {
+    /* eslint-disable */
+    resp.push({
+      ...template,
+      address,
+      chain_stats: {
+        funded_txo_count: randomNum(100),
+        funded_txo_sum: Math.max(randomNum(1000000), 10000),
+        spent_txo_count: randomNum(100),
+        spent_txo_sum: randomNum(10000),
+        tx_count: randomNum(100),
+      },
+      mempool_stats: {
+        funded_txo_count: randomNum(100),
+        funded_txo_sum: Math.max(randomNum(1000000), 10000),
+        spent_txo_count: randomNum(100),
+        spent_txo_sum: randomNum(10000),
+        tx_count: randomNum(100),
+      },
+    });
+    /* eslint-disable */
+  }
+  return resp;
+}
+
+/**
+ * Method to generate blockchair getBalance resp by addresses.
+ *
+ * @param addresses - Array of address in string.
+ * @returns An array of blockchair getBalance response.
+ */
+export function generateBlockChairGetBalanceResp(addresses: string[]) {
+  const template = blockChairData.getBalanceResp;
+  const resp: typeof template = { ...template, data: {} };
+  for (const address of addresses) {
+    resp.data[address] = randomNum(1000000);
+  }
+  return resp;
+}


### PR DESCRIPTION
This PR is to 
- add blockchair data provider
- update get balance methods to get balances, and accept multiple address and assets
- update the response for get balances rpc
- update chain id format to CAIP-19 standard