### PR TITLE
fix: remove unuse code in BaseSnapRpcHandler

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/bitcoin.git"
   },
   "source": {
-    "shasum": "kCyawnub+hxegviL49Qojh2EWrjCFQBufNI1iGF4q18=",
+    "shasum": "rWA8p3lwhc7PyoKokMPwssnTRiWd4ZeKbMes2iiDhos=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/rpcs/base.ts
+++ b/packages/snap/src/rpcs/base.ts
@@ -12,23 +12,6 @@ import {
   SnapRpcHandlerRequestStruct,
 } from './types';
 
-abstract class Parent {
-  static readonly staticMemeber: string;
-
-  protected myProtectedMethod() {
-    console.log((this.constructor as typeof Parent).staticMemeber);
-  }
-}
-
-class Child extends Parent {
-  static readonly staticMemeber = 'Hello, world!';
-
-  public doSomething() {
-    this.myProtectedMethod();
-  }
-}
-new Child().doSomething();
-
 export abstract class BaseSnapRpcHandler implements ISnapRpcExecutable {
   static instance: ISnapRpcHandler | null = null;
 
@@ -62,6 +45,10 @@ export abstract class BaseSnapRpcHandler implements ISnapRpcExecutable {
   }
 
   protected async postExecute(response: SnapRpcHandlerResponse): Promise<void> {
+    logger.info(
+      `[SnapRpcHandler.postExecute] Response: ${JSON.stringify(response)}`,
+    );
+
     try {
       if (this.responseStruct) {
         assert(response, this.responseStruct);
@@ -71,10 +58,6 @@ export abstract class BaseSnapRpcHandler implements ISnapRpcExecutable {
       logger.info(`[SnapRpcHandler.postExecute] Error: ${error.message}`);
       throw new SnapRpcValidationError('Response is invalid');
     }
-
-    logger.info(
-      `[SnapRpcHandler.postExecute] Response: ${JSON.stringify(response)}`,
-    );
   }
 
   async execute(


### PR DESCRIPTION
## Description
This PR is to remove the unuse code in BaseSnapRpcHandler
this PR also update a small change on the class BaseSnapRpcHandler, it move the logging at the beginning of the code in method postExecute

### Related ticket

Fixes #

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
