### PR TITLE
feat: add ListAccountsButton card

### DIFF
--- a/packages/example/src/components/Buttons.tsx
+++ b/packages/example/src/components/Buttons.tsx
@@ -111,6 +111,10 @@ export const GetBTCAccountBalanceButton = (
   return <Button {...props}>Get BTC Account balance</Button>;
 };
 
+export const ListAccountsButton = (props: ComponentProps<typeof Button>) => {
+  return <Button {...props}>List Accounts</Button>;
+};
+
 export const SellBTCButton = (props: ComponentProps<typeof Button>) => {
   return <Button {...props}>Sell your BTC</Button>;
 };

--- a/packages/example/src/hooks/index.ts
+++ b/packages/example/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './MetamaskContext';
 export * from './useInvokeSnap';
+export * from './useInvokeKeyring';
 export * from './useMetaMask';
 export * from './useRequest';
 export * from './useRequestSnap';

--- a/packages/example/src/hooks/useInvokeKeyring.ts
+++ b/packages/example/src/hooks/useInvokeKeyring.ts
@@ -1,0 +1,42 @@
+import { defaultSnapOrigin } from '../config';
+import { useRequest } from './useRequest';
+
+export type InvokeKeyringParams = {
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+// FIXME: We should use the keyring's client provided by @metamask/keyring-api instead.
+
+/**
+ * Utility hook to wrap the `wallet_invokeKeyring` method.
+ *
+ * @param snapId - The Snap ID to invoke. Defaults to the snap ID specified in the
+ * config.
+ * @returns The invokeKeyring wrapper method.
+ */
+export const useInvokeKeyring = (snapId = defaultSnapOrigin) => {
+  const request = useRequest();
+
+  /**
+   * Invoke the requested Keyring method.
+   *
+   * @param params - The invoke params.
+   * @param params.method - The method name.
+   * @param params.params - The method params.
+   * @returns The Keyring response.
+   */
+  const invokeKeyring = async ({ method, params }: InvokeKeyringParams) =>
+    request({
+      method: 'wallet_invokeKeyring',
+      params: {
+        snapId,
+        request: {
+          method,
+          params,
+        },
+      },
+    });
+
+  return invokeKeyring;
+};

--- a/packages/example/src/pages/index.tsx
+++ b/packages/example/src/pages/index.tsx
@@ -10,12 +10,14 @@ import {
   Card,
   CreateBTCAccountButton,
   GetBTCAccountBalanceButton,
+  ListAccountsButton,
 } from '../components';
 import { defaultSnapOrigin } from '../config';
 import { defaultSnapOrigin as snapId } from '../config/snap';
 import {
   useMetaMask,
   useInvokeSnap,
+  useInvokeKeyring,
   useMetaMaskContext,
   useRequestSnap,
 } from '../hooks';
@@ -95,6 +97,7 @@ const Index = () => {
   const { isFlask, snapsDetected, installedSnap } = useMetaMask();
   const requestSnap = useRequestSnap();
   const invokeSnap = useInvokeSnap();
+  const invokeKeyring = useInvokeKeyring();
   const [btcAccount, setBtcAccount] = useState<KeyringAccount>();
   const [balance, setBalance] = useState<string>('');
 
@@ -139,6 +142,16 @@ const Index = () => {
     const total = accountBalance?.balances?.[address]?.[asset];
 
     setBalance(total?.amount);
+  };
+
+  const handleListAccountClick = async () => {
+    const accounts = (await invokeKeyring({
+      method: 'keyring_listAccounts',
+    })) as KeyringAccount[];
+
+    if (accounts.length) {
+      setBtcAccount(accounts[0]);
+    }
   };
 
   return (
@@ -202,6 +215,24 @@ const Index = () => {
             button: (
               <CreateBTCAccountButton
                 onClick={handleCreateAccountClick}
+                disabled={!installedSnap}
+              />
+            ),
+          }}
+          disabled={!installedSnap}
+          fullWidth={
+            isMetaMaskReady &&
+            Boolean(installedSnap) &&
+            !shouldDisplayReconnectButton(installedSnap)
+          }
+        />
+        <Card
+          content={{
+            title: 'List Account',
+            description: `List BTC Account from Snap state`,
+            button: (
+              <ListAccountsButton
+                onClick={handleListAccountClick}
                 disabled={!installedSnap}
               />
             ),

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/bitcoin.git"
   },
   "source": {
-    "shasum": "UpQ57ZHPwpSRYZn/lGILdQlrLk38KBZXkPcaW+bRajQ=",
+    "shasum": "rLfn/qFNzc5cwG+Ives5d8n0hmKK5A2AGP4Zv+SDiK8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
A new card to actually list your BTC account from the Snap state.

This might be useful when you want to fetch your account from the Snap after reloading the page.