### PR TITLE
fix: update btc asset

### DIFF
--- a/packages/example/src/pages/index.tsx
+++ b/packages/example/src/pages/index.tsx
@@ -99,7 +99,7 @@ const Index = () => {
   const [balance, setBalance] = useState<string>('');
 
   const scope = "bip122:000000000933ea01ad0ee984209779ba"
-  const asset = `${scope}:slip44:0`
+  const asset = `${scope}:slip44/0`
 
   const isMetaMaskReady = isLocalSnap(defaultSnapOrigin)
     ? isFlask

--- a/packages/snap/src/modules/bitcoin/constants.ts
+++ b/packages/snap/src/modules/bitcoin/constants.ts
@@ -15,6 +15,6 @@ export enum DataClient {
 }
 
 export enum BtcAsset {
-  Btc = 'bip122:000000000019d6689c085ae165831e93:slip44:0',
-  TBtc = 'bip122:000000000933ea01ad0ee984209779ba:slip44:0',
+  Btc = 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+  TBtc = 'bip122:000000000933ea01ad0ee984209779ba/slip44:0',
 }


### PR DESCRIPTION
## Description
This PR is to fix the incorrect BTC asset in constants

instead of
```
export enum BtcAsset {
  Btc = 'bip122:000000000019d6689c085ae165831e93:slip44:0',
  TBtc = 'bip122:000000000933ea01ad0ee984209779ba:slip44:0',
}
```

it should be
```
export enum BtcAsset {
  Btc = 'bip122:000000000019d6689c085ae165831e93/slip44:0',
  TBtc = 'bip122:000000000933ea01ad0ee984209779ba/slip44:0',
}
```


### Related ticket

Fixes #

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
