### PR TITLE
fix: update resp of onChainService - boardcastTransaction

### DIFF
--- a/packages/snap/src/chain.ts
+++ b/packages/snap/src/chain.ts
@@ -44,10 +44,14 @@ export type Pagination = {
   offset: number;
 };
 
+export type CommitedTransaction = {
+  transactionId: string;
+};
+
 export type IOnChainService = {
   getBalances(addresses: string[], assets: string[]): Promise<AssetBalances>;
   estimateFees(): Promise<Fees>;
-  boardcastTransaction(signedTransaction: string): Promise<string>;
+  boardcastTransaction(signedTransaction: string): Promise<CommitedTransaction>;
   listTransactions(address: string, pagination: Pagination);
   getTransaction(txnHash: string);
   getDataForTransaction(

--- a/packages/snap/src/modules/bitcoin/chain/service.test.ts
+++ b/packages/snap/src/modules/bitcoin/chain/service.test.ts
@@ -234,7 +234,9 @@ describe('BtcOnChainService', () => {
       const result = await txnService.boardcastTransaction(signedTransaction);
 
       expect(sendTransactionSpy).toHaveBeenCalledWith(signedTransaction);
-      expect(result).toStrictEqual(resp.data.transaction_hash);
+      expect(result).toStrictEqual({
+        transactionId: resp.data.transaction_hash,
+      });
     });
 
     it('throws BtcOnChainServiceErrorr if write client execute fail', async () => {

--- a/packages/snap/src/modules/bitcoin/chain/service.ts
+++ b/packages/snap/src/modules/bitcoin/chain/service.ts
@@ -10,6 +10,7 @@ import type {
   Pagination,
   Fees,
   TransactionData,
+  CommitedTransaction,
 } from '../../../chain';
 import { compactError } from '../../../utils';
 import { BtcAsset } from '../constants';
@@ -119,9 +120,16 @@ export class BtcOnChainService implements IOnChainService {
     }
   }
 
-  async boardcastTransaction(signedTransaction: string): Promise<string> {
+  async boardcastTransaction(
+    signedTransaction: string,
+  ): Promise<CommitedTransaction> {
     try {
-      return await this.writeClient.sendTransaction(signedTransaction);
+      const transactionId = await this.writeClient.sendTransaction(
+        signedTransaction,
+      );
+      return {
+        transactionId,
+      };
     } catch (error) {
       throw compactError(error, BtcOnChainServiceError);
     }

--- a/packages/snap/src/rpcs/broadcast-transaction.test.ts
+++ b/packages/snap/src/rpcs/broadcast-transaction.test.ts
@@ -31,7 +31,9 @@ describe('BroadcastTransactionHandler', () => {
     it('broadcast an transaction', async () => {
       const { boardcastTransactionSpy } = createMockChainApiFactory();
       const resp = generateBlockChairBroadcastTransactionResp();
-      boardcastTransactionSpy.mockResolvedValue(resp.data.transaction_hash);
+      boardcastTransactionSpy.mockResolvedValue({
+        transactionId: resp.data.transaction_hash,
+      });
 
       const result = await BroadcastTransactionHandler.getInstance().execute({
         scope: Network.Testnet,

--- a/packages/snap/src/rpcs/broadcast-transaction.ts
+++ b/packages/snap/src/rpcs/broadcast-transaction.ts
@@ -46,12 +46,6 @@ export class BroadcastTransactionHandler
 
     const chainApi = Factory.createOnChainServiceProvider(scope);
 
-    const transactionId = await chainApi.boardcastTransaction(
-      signedTransaction,
-    );
-
-    return {
-      transactionId,
-    };
+    return await chainApi.boardcastTransaction(signedTransaction);
   }
 }


### PR DESCRIPTION
## Description
This PR is to update the BtcOnChainService's method `boardcastTransaction`
instead of returning a string , but return the same respone as chain api `chain_broadcastTransaction`

it is because when chain service separate into an individual snap,  we can re use the interface IOnChainService to communicate to that new snap

### Related ticket

Fixes #

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
