### PR TITLE
chore: update snap provider instance name

### DIFF
--- a/packages/snap/src/keyring/keyring.test.ts
+++ b/packages/snap/src/keyring/keyring.test.ts
@@ -246,6 +246,32 @@ describe('BtcKeyring', () => {
       ).rejects.toThrow('Account not found');
     });
 
+    it("throws `Account's scope does not match with the request's scope` error if given scope is not match with the account", async () => {
+      const { instance: stateMgr, getWalletSpy } = createMockStateMgr();
+      const { instance: keyring } = createMockKeyring(stateMgr);
+      const account = generateAccounts(1)[0];
+
+      getWalletSpy.mockResolvedValue({
+        account,
+        index: account.options.index,
+        scope: account.options.scope,
+        hdPath: getHdPath(account.options.index),
+      });
+
+      await expect(
+        keyring.submitRequest({
+          id: account.id,
+          scope: Network.Mainnet,
+          account: account.address,
+          request: {
+            method: 'btc_sendmany',
+          },
+        }),
+      ).rejects.toThrow(
+        "Account's scope does not match with the request's scope",
+      );
+    });
+
     it('throws MethodNotFoundError if the method not support', async () => {
       const { instance: stateMgr } = createMockStateMgr();
       const { instance: keyring } = createMockKeyring(stateMgr);

--- a/packages/snap/src/keyring/keyring.ts
+++ b/packages/snap/src/keyring/keyring.ts
@@ -186,7 +186,7 @@ export class BtcKeyring implements Keyring {
   ): Promise<void> {
     // TODO: Temp solutio to support keyring in snap without keyring API
     if (this.options.emitEvents) {
-      await emitSnapKeyringEvent(SnapHelper.wallet, event, data);
+      await emitSnapKeyringEvent(SnapHelper.provider, event, data);
     }
   }
 

--- a/packages/snap/src/modules/snap/helpers.test.ts
+++ b/packages/snap/src/modules/snap/helpers.test.ts
@@ -10,7 +10,7 @@ jest.mock('@metamask/key-tree', () => ({
 describe('SnapHelper', () => {
   describe('getBip44Deriver', () => {
     it('gets bip44 deriver', async () => {
-      const spy = jest.spyOn(SnapHelper.wallet, 'request');
+      const spy = jest.spyOn(SnapHelper.provider, 'request');
       const coinType = 1001;
 
       await SnapHelper.getBip44Deriver(coinType);
@@ -26,7 +26,7 @@ describe('SnapHelper', () => {
 
   describe('getBip32Deriver', () => {
     it('gets bip32 deriver', async () => {
-      const spy = jest.spyOn(SnapHelper.wallet, 'request');
+      const spy = jest.spyOn(SnapHelper.provider, 'request');
       const path = ['m', "84'", "0'"];
       const curve = 'secp256k1';
 
@@ -44,7 +44,7 @@ describe('SnapHelper', () => {
 
   describe('confirmDialog', () => {
     it('calls snap_dialog', async () => {
-      const spy = jest.spyOn(SnapHelper.wallet, 'request');
+      const spy = jest.spyOn(SnapHelper.provider, 'request');
       const testcase = {
         header: 'header',
         subHeader: 'subHeader',
@@ -78,7 +78,7 @@ describe('SnapHelper', () => {
 
   describe('getStateData', () => {
     it('gets state data', async () => {
-      const spy = jest.spyOn(SnapHelper.wallet, 'request');
+      const spy = jest.spyOn(SnapHelper.provider, 'request');
       const testcase = {
         state: {
           transaction: [
@@ -106,7 +106,7 @@ describe('SnapHelper', () => {
 
   describe('setStateData', () => {
     it('sets state data', async () => {
-      const spy = jest.spyOn(SnapHelper.wallet, 'request');
+      const spy = jest.spyOn(SnapHelper.provider, 'request');
       const testcase = {
         state: {
           transaction: [

--- a/packages/snap/src/modules/snap/helpers.ts
+++ b/packages/snap/src/modules/snap/helpers.ts
@@ -15,12 +15,12 @@ import {
 declare const snap: SnapsProvider;
 
 export class SnapHelper {
-  static wallet: SnapsProvider = snap;
+  static provider: SnapsProvider = snap;
 
   static async getBip44Deriver(
     coinType: number,
   ): Promise<BIP44AddressKeyDeriver> {
-    const bip44Node = await SnapHelper.wallet.request({
+    const bip44Node = await SnapHelper.provider.request({
       method: 'snap_getBip44Entropy',
       params: {
         coinType,
@@ -33,7 +33,7 @@ export class SnapHelper {
     path: string[],
     curve: 'secp256k1' | 'ed25519',
   ): Promise<SLIP10NodeInterface> {
-    const node = await SnapHelper.wallet.request({
+    const node = await SnapHelper.provider.request({
       method: 'snap_getBip32Entropy',
       params: {
         path,
@@ -48,7 +48,7 @@ export class SnapHelper {
     subHeader: string,
     body: Record<string, string>,
   ): Promise<DialogResult> {
-    return SnapHelper.wallet.request({
+    return SnapHelper.provider.request({
       method: 'snap_dialog',
       params: {
         type: 'confirmation',
@@ -65,7 +65,7 @@ export class SnapHelper {
   }
 
   static async getStateData<State>(): Promise<State> {
-    return (await SnapHelper.wallet.request({
+    return (await SnapHelper.provider.request({
       method: 'snap_manageState',
       params: {
         operation: 'get',
@@ -74,7 +74,7 @@ export class SnapHelper {
   }
 
   static async setStateData<State>(data: State) {
-    await SnapHelper.wallet.request({
+    await SnapHelper.provider.request({
       method: 'snap_manageState',
       params: {
         operation: 'update',


### PR DESCRIPTION
## Description
This PR is to update the provider name in SnapHelper from `wallet`  to `provider`

### Related ticket

Fixes #

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
