### PR TITLE
chore: allow Portfolio to call `keyring_getAccountBalances`

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -38,7 +38,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/keyring-api": "^6.3.1",
+    "@metamask/keyring-api": "^8.0.0",
     "@metamask/snaps-cli": "^6.1.0",
     "@metamask/snaps-jest": "^8.0.0",
     "@metamask/snaps-sdk": "^4.0.0",

--- a/packages/snap/src/permissions.ts
+++ b/packages/snap/src/permissions.ts
@@ -18,6 +18,7 @@ const dappPermissions = new Set([
   KeyringRpcMethod.ApproveRequest,
   KeyringRpcMethod.RejectRequest,
   KeyringRpcMethod.SubmitRequest,
+  KeyringRpcMethod.GetAccountBalances,
   // Chain API methods
   InternalRpcMethod.GetTransactionStatus,
 ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2744,7 +2744,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/key-tree": ^9.0.0
-    "@metamask/keyring-api": ^6.3.1
+    "@metamask/keyring-api": ^8.0.0
     "@metamask/snaps-cli": ^6.1.0
     "@metamask/snaps-jest": ^8.0.0
     "@metamask/snaps-sdk": ^4.0.0
@@ -3013,7 +3013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^6.0.0, @metamask/keyring-api@npm:^6.3.1":
+"@metamask/keyring-api@npm:^6.0.0":
   version: 6.4.0
   resolution: "@metamask/keyring-api@npm:6.4.0"
   dependencies:
@@ -3026,6 +3026,22 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ">=15 <18"
   checksum: 7845ed5fa73db3165703c2142b6062d03ca5fea329b54d28f424dee2bb393edc1f9a015e771289ef7236c31f30355bf2c52ad74bb47cf531c09c5eec66e06b00
+  languageName: node
+  linkType: hard
+
+"@metamask/keyring-api@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@metamask/keyring-api@npm:8.0.0"
+  dependencies:
+    "@metamask/snaps-sdk": ^4.2.0
+    "@metamask/utils": ^8.4.0
+    "@types/uuid": ^9.0.8
+    bech32: ^2.0.0
+    superstruct: ^1.0.3
+    uuid: ^9.0.1
+  peerDependencies:
+    "@metamask/providers": ">=15 <18"
+  checksum: 945d4bdb69d2eea60bd990d6372a7b8e5740a1c7aa66361ad1fa309273f05ec0543edea84524ed266e8e06a38fd4727869da646306682e5fa0d52c8ccc393c4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is to allows Portfolio to call the `keyring_getAccountBalances` Keyring API method.

Jira: https://consensyssoftware.atlassian.net/jira/software/projects/BS/boards/681?selectedIssue=BS-30