### PR TITLE
fix: audit report 4.15 - get balances duplicate validation

### DIFF
--- a/packages/snap/src/rpcs/get-balances.ts
+++ b/packages/snap/src/rpcs/get-balances.ts
@@ -1,5 +1,5 @@
 import type { Infer } from 'superstruct';
-import { object, array, record, enums, assert } from 'superstruct';
+import { object, array, record, enums } from 'superstruct';
 
 import type { BtcAccount } from '../bitcoin/wallet';
 import { Config } from '../config';
@@ -49,8 +49,6 @@ export async function getBalances(
 ) {
   try {
     validateRequest(params, getBalancesRequestStruct);
-
-    assert(params, getBalancesRequestStruct);
 
     const { assets, scope } = params;
 


### PR DESCRIPTION
This PR is to fix the comment on
[KeyRing - getBalances Duplicate Runtime Input Validation](https://consensys.io/diligence/audits/private/gxpsmn6kwnfl3b/#keyring---getbalances-duplicate-runtime-input-validation)

The solution is to remove the duplicate validation