### PR TITLE
fix: emit event on account creation

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "nesNdD9sbf5hIRuNZuR83IpfHPYs8VcYSwNgMn7doNc=",
+    "shasum": "MNqMqbvHPft1pwBj4zRmvCAVw4LBRO41duCJy2HRRJU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/rpcs/create-account.ts
+++ b/packages/snap/src/rpcs/create-account.ts
@@ -25,7 +25,7 @@ export async function createAccount(
 ): Promise<CreateAccountResponse> {
   const keyring = new BtcKeyring(new KeyringStateManager(), {
     defaultIndex: Config.wallet.defaultAccountIndex,
-    emitEvents: false,
+    emitEvents: true,
   });
 
   const account = await keyring.createAccount({


### PR DESCRIPTION
This PR fixes the Snap to emit events on account creation, informing MetaMask about the new account and adding it to the accounts list.