### PR TITLE
ci: ignore Snap manifest (to be reverted)

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Require clean working directory
         shell: bash
         run: |
-          if ! git diff --exit-code; then
+          if ! git diff --exit-code -- ':!/packages/snap/snap.manifest.json'; then
             echo "Working tree dirty at end of job"
             exit 1
           fi
@@ -68,7 +68,7 @@ jobs:
       - name: Require clean working directory
         shell: bash
         run: |
-          if ! git diff --exit-code; then
+          if ! git diff --exit-code -- ':!/packages/snap/snap.manifest.json'; then
             echo "Working tree dirty at end of job"
             exit 1
           fi
@@ -94,7 +94,7 @@ jobs:
       - name: Require clean working directory
         shell: bash
         run: |
-          if ! git diff --exit-code; then
+          if ! git diff --exit-code -- ':!/packages/snap/snap.manifest.json'; then
             echo "Working tree dirty at end of job"
             exit 1
           fi


### PR DESCRIPTION
This PR should be reverted after the initial development phase.