### PR TITLE
refactor: add reusable error

### DIFF
--- a/packages/snap/src/exceptions.ts
+++ b/packages/snap/src/exceptions.ts
@@ -1,0 +1,19 @@
+import { CustomError } from './utils';
+
+export class AccountNotFoundError extends CustomError {
+  constructor(errMsg?: string) {
+    super(errMsg ?? `Account not found`);
+  }
+}
+
+export class MethodNotImplementedError extends CustomError {
+  constructor(errMsg?: string) {
+    super(errMsg ?? `Method not implemented`);
+  }
+}
+
+export class FeeRateUnavailableError extends CustomError {
+  constructor(errMsg?: string) {
+    super(errMsg ?? `No fee rates available`);
+  }
+}

--- a/packages/snap/src/keyring.test.ts
+++ b/packages/snap/src/keyring.test.ts
@@ -1,11 +1,12 @@
 import type { KeyringAccount } from '@metamask/keyring-api';
-import { MethodNotFoundError } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, UnauthorizedError } from '@metamask/snaps-sdk';
 import { v4 as uuidv4 } from 'uuid';
 
 import { generateAccounts } from '../test/utils';
 import { BtcAccount, BtcWallet, ScriptType } from './bitcoin/wallet';
 import { Config } from './config';
 import { Caip2Asset, Caip2ChainId } from './constants';
+import { AccountNotFoundError, MethodNotImplementedError } from './exceptions';
 import { Factory } from './factory';
 import { BtcKeyring } from './keyring';
 import * as getBalanceRpc from './rpcs/get-balances';
@@ -277,13 +278,13 @@ describe('BtcKeyring', () => {
   });
 
   describe('updateAccount', () => {
-    it('throws `Method not implemented` error', async () => {
+    it('throws `MethodNotImplementedError`', async () => {
       const { instance: stateMgr } = createMockStateMgr();
       const { instance: keyring } = createMockKeyring(stateMgr);
       const account = generateAccounts(1)[0];
 
       await expect(keyring.updateAccount(account)).rejects.toThrow(
-        'Method not implemented.',
+        MethodNotImplementedError,
       );
     });
   });
@@ -354,7 +355,7 @@ describe('BtcKeyring', () => {
       );
     });
 
-    it('throws `Account not found` error if the account address is not match with the unlocked account', async () => {
+    it('throws `AccountNotFoundError` if the account address is not match with the unlocked account', async () => {
       const caip2ChainId = Caip2ChainId.Testnet;
       const { instance: stateMgr, getWalletSpy } = createMockStateMgr();
       const { instance: keyring } = createMockKeyring(stateMgr);
@@ -376,10 +377,10 @@ describe('BtcKeyring', () => {
             method: 'btc_sendmany',
           },
         }),
-      ).rejects.toThrow('Account not found');
+      ).rejects.toThrow(AccountNotFoundError);
     });
 
-    it('throws `Account not found` error if the account id not found from state', async () => {
+    it('throws `AccountNotFoundError` if the account id not found from state', async () => {
       const { instance: stateMgr } = createMockStateMgr();
       const { instance: keyring } = createMockKeyring(stateMgr);
       const account = generateAccounts(1)[0];
@@ -393,7 +394,7 @@ describe('BtcKeyring', () => {
             method: 'btc_sendmany',
           },
         }),
-      ).rejects.toThrow('Account not found');
+      ).rejects.toThrow(AccountNotFoundError);
     });
 
     it("throws `Account's scope does not match with the request's scope` error if given scope is not match with the account", async () => {
@@ -422,7 +423,7 @@ describe('BtcKeyring', () => {
       );
     });
 
-    it('throws MethodNotFoundError if the method not support', async () => {
+    it('throws `MethodNotFoundError` if the method not support', async () => {
       const caip2ChainId = Caip2ChainId.Testnet;
       const { instance: stateMgr, getWalletSpy } = createMockStateMgr();
       const { instance: keyring } = createMockKeyring(stateMgr);
@@ -449,7 +450,7 @@ describe('BtcKeyring', () => {
       ).rejects.toThrow(MethodNotFoundError);
     });
 
-    it('throws `Forbidden method` error if the method is not allowed from the account', async () => {
+    it('throws `UnauthorizedError` if the method is not allowed from the account', async () => {
       const caip2ChainId = Caip2ChainId.Testnet;
       const { instance: stateMgr, getWalletSpy } = createMockStateMgr();
       const { instance: keyring } = createMockKeyring(stateMgr);
@@ -471,7 +472,7 @@ describe('BtcKeyring', () => {
             method: 'btc_methodDoesNotExist',
           },
         }),
-      ).rejects.toThrow('Forbidden method');
+      ).rejects.toThrow(UnauthorizedError);
     });
   });
 

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -8,13 +8,18 @@ import {
   type Balance,
   type CaipAssetType,
 } from '@metamask/keyring-api';
-import { MethodNotFoundError, type Json } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  UnauthorizedError,
+  type Json,
+} from '@metamask/snaps-sdk';
 import type { Infer } from 'superstruct';
 import { assert, object, StructError } from 'superstruct';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { BtcAccount, BtcWallet } from './bitcoin/wallet';
 import { Config } from './config';
+import { AccountNotFoundError, MethodNotImplementedError } from './exceptions';
 import { Factory } from './factory';
 import { getBalances, type SendManyParams, sendMany } from './rpcs';
 import type { KeyringStateManager, Wallet } from './stateManagement';
@@ -121,7 +126,7 @@ export class BtcKeyring implements Keyring {
   }
 
   async updateAccount(_account: KeyringAccount): Promise<void> {
-    throw new Error('Method not implemented.');
+    throw new MethodNotImplementedError();
   }
 
   async deleteAccount(id: string): Promise<void> {
@@ -214,7 +219,7 @@ export class BtcKeyring implements Keyring {
     const walletData = await this._stateMgr.getWallet(id);
 
     if (!walletData) {
-      throw new Error('Account not found');
+      throw new AccountNotFoundError();
     }
 
     return walletData;
@@ -237,7 +242,7 @@ export class BtcKeyring implements Keyring {
     keyringAccount: KeyringAccount,
   ): void {
     if (!account || account.address !== keyringAccount.address) {
-      throw new Error('Account not found');
+      throw new AccountNotFoundError();
     }
   }
 
@@ -246,7 +251,7 @@ export class BtcKeyring implements Keyring {
     keyringAccount: KeyringAccount,
   ): void {
     if (!keyringAccount.methods.includes(method)) {
-      throw new Error('Forbidden method');
+      throw new UnauthorizedError(`Permission denied`) as unknown as Error;
     }
   }
 

--- a/packages/snap/src/rpcs/sendmany.ts
+++ b/packages/snap/src/rpcs/sendmany.ts
@@ -25,6 +25,7 @@ import {
   type ITxInfo,
   TxValidationError,
 } from '../bitcoin/wallet';
+import { FeeRateUnavailableError } from '../exceptions';
 import { Factory } from '../factory';
 import {
   ScopeStruct,
@@ -109,7 +110,7 @@ export async function sendMany(
     const feesResp = await chainApi.getFeeRates();
 
     if (feesResp.fees.length === 0) {
-      throw new Error('No fee rates available');
+      throw new FeeRateUnavailableError();
     }
 
     const fee = Math.max(


### PR DESCRIPTION
This PR is to add reusable errors for 
- "Account not found", 
- "Method not implemented",
- "No fee rates available"

And it also update the "Forbidden method" error from keyring.ts to UnauthorizedError(`Permission denied`) , which to categorised as an general SNAP error