### PR TITLE
fix: unexpected error message in MethodNotFoundError

### DIFF
--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -44,7 +44,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
           request.params as GetTransactionStatusParams,
         );
       default:
-        throw new MethodNotFoundError(method) as unknown as Error;
+        throw new MethodNotFoundError() as unknown as Error;
     }
   } catch (error) {
     let snapError = error;

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -173,7 +173,7 @@ export class BtcKeyring implements Keyring {
           scope: walletData.scope,
         } as unknown as SendManyParams)) as unknown as Json;
       default:
-        throw new MethodNotFoundError(method) as unknown as Error;
+        throw new MethodNotFoundError() as unknown as Error;
     }
   }
 


### PR DESCRIPTION
This PR is to fix the unexpected error message in MethodNotFoundError

when MethodNotFoundError passing with an argument, it will use the argument as the error message 
