### PR TITLE
feat: emit acccount suggested name from Snap

### DIFF
--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -19,6 +19,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type { BtcAccount, BtcWallet } from './bitcoin/wallet';
 import { Config } from './config';
+import { Caip2ChainId } from './constants';
 import { AccountNotFoundError, MethodNotImplementedError } from './exceptions';
 import { Factory } from './factory';
 import { getBalances, type SendManyParams, sendMany } from './rpcs';
@@ -109,6 +110,7 @@ export class BtcKeyring implements Keyring {
 
         await this.#emitEvent(KeyringEvent.AccountCreated, {
           account: keyringAccount,
+          accountNameSuggestion: this.getKeyringAccountNameSuggestion(options),
         });
       });
 
@@ -265,5 +267,20 @@ export class BtcKeyring implements Keyring {
       },
       methods: this._methods,
     } as unknown as KeyringAccount;
+  }
+
+  protected getKeyringAccountNameSuggestion(
+    options?: CreateAccountOptions,
+  ): string {
+    switch (options?.scope) {
+      case Caip2ChainId.Mainnet:
+        return 'Bitcoin Account';
+      case Caip2ChainId.Testnet:
+        return 'Bitcoin Testnet Account';
+
+      default:
+        // Leave it blank to fallback to auto-suggested name on the extension side
+        return '';
+    }
   }
 }


### PR DESCRIPTION
## Description

The Snap now emits an account suggested name that can be consumed by the extension when creating the account.

This PR goes in pair with this extension's PR too:
- https://github.com/MetaMask/metamask-extension/pull/26183

## Recording

> [!WARNING]
> There is an intermediary screen, since we installed the Snap manually, so we cannot skip the "confirmation" dialogs, so this is expected!

https://github.com/user-attachments/assets/39a33d9e-395d-4a36-b1aa-51f46dda871d