### PR TITLE
fix: align shorten address format with extension

### DIFF
--- a/packages/snap/src/utils/string.test.ts
+++ b/packages/snap/src/utils/string.test.ts
@@ -80,6 +80,6 @@ describe('replaceMiddleChar', () => {
 describe('shortenAddress', () => {
   const str = 'tb1qt2mpt38wmgw3j0hnr9mp5hsa7kxf2a3ktdxaeu';
   it('shorten an address', () => {
-    expect(shortenAddress(str)).toBe('tb1qt...aeu');
+    expect(shortenAddress(str)).toBe('tb1qt2m...dxaeu');
   });
 });

--- a/packages/snap/src/utils/string.ts
+++ b/packages/snap/src/utils/string.ts
@@ -74,5 +74,5 @@ export function replaceMiddleChar(
  * @returns The formatted address.
  */
 export function shortenAddress(address: string) {
-  return replaceMiddleChar(address, 5, 3);
+  return replaceMiddleChar(address, 7, 5);
 }


### PR DESCRIPTION
This PR is to align the snap's shorten address format with extension



Extension address format:
![image](https://github.com/user-attachments/assets/4c0f50b5-9eed-4232-b9cb-573c21784759)
