### PR TITLE
refactor: add configurable visibility of the dialog in the RPC `btc_sendmany`

### DIFF
--- a/packages/snap/src/permissions.ts
+++ b/packages/snap/src/permissions.ts
@@ -29,7 +29,7 @@ const metamaskPermissions = new Set([
   KeyringRpcMethod.GetAccountBalances,
 ]);
 
-const allowedOrigins = [
+export const allowedOrigins = [
   'https://portfolio.metamask.io',
   'https://portfolio-builds.metafi-dev.codefi.network',
   'https://dev.portfolio.metamask.io',
@@ -37,7 +37,7 @@ const allowedOrigins = [
   'https://ramps-dev.portfolio.metamask.io',
 ];
 
-const metamask = 'metamask';
+export const metamask = 'metamask';
 
 export const originPermissions = new Map<string, Set<string>>([]);
 


### PR DESCRIPTION
This PR is to modify the rpc handler of `btc_sendmany` to accept a new configuration that enable/disable the visibility of confirmation dialog and warning dialog

new configuration in sendMany:
```typescript
async function sendMany(
  account: BtcAccount,
  origin: string,
  params: SendManyParams,
  // new configuration
  configuration: SendManyConfiguration = {
    showConfirmation: true,
    showWarning: true,
  },
) 
```

the idea is to enable the caller `keyring` to choose to show / hide the dialog base on origin

when the origin is metamask, we should set the `showConfirmation` and `showWarning` to false
else we should set them to true