### PR TITLE
fix:  resolve unexpected error in `estimateFee` RPC when the account has insufficient funds

### DIFF
--- a/packages/snap/src/bitcoin/wallet/coin-select.test.ts
+++ b/packages/snap/src/bitcoin/wallet/coin-select.test.ts
@@ -69,5 +69,27 @@ describe('CoinSelectService', () => {
       expect(result.inputs.length).toBeGreaterThan(0);
       expect(result.outputs.length).toBeGreaterThan(0);
     });
+
+    it('returns empty inputs and outputs when the provided UTXOs are insufficient', async () => {
+      const network = networks.testnet;
+      // Setup a test case where required utxos are greater than the available utxos
+      const { inputs, outputs, sender } = await prepareCoinSlect(
+        network,
+        10000,
+        500,
+        500,
+      );
+
+      const coinSelectService = new CoinSelectService(1);
+
+      const result = coinSelectService.selectCoins(
+        inputs,
+        outputs,
+        new TxOutput(0, sender.address, sender.script),
+      );
+
+      expect(result.inputs).toHaveLength(0);
+      expect(result.outputs).toHaveLength(0);
+    });
   });
 });

--- a/packages/snap/src/bitcoin/wallet/coin-select.ts
+++ b/packages/snap/src/bitcoin/wallet/coin-select.ts
@@ -34,7 +34,9 @@ export class CoinSelectService {
 
     const selectedResult: SelectionResult = {
       fee: result.fee,
-      inputs: result.inputs,
+      // CoinSelect returns undefined inputs when the provided UTXOs are insufficient,
+      // Hence, assign an empty array to standardize the return value
+      inputs: result.inputs ?? [],
       outputs: [],
     };
 

--- a/packages/snap/src/bitcoin/wallet/wallet.ts
+++ b/packages/snap/src/bitcoin/wallet/wallet.ts
@@ -130,7 +130,10 @@ export class BtcWallet {
       feeRate,
     );
 
-    if (!selectionResult.inputs || !selectionResult.outputs) {
+    if (
+      selectionResult.inputs.length === 0 ||
+      selectionResult.outputs.length === 0
+    ) {
       throw new InsufficientFundsError();
     }
 


### PR DESCRIPTION
There is a bug if calling `estimateFee` RPC when the account has insufficient funds

Due to `CoinSelectService` assign un-define to the `result.inputs` and `estimateFee` RPC contains a line to check result.inputs.length  === 0

To standardized the output of CoinSelectService, it is better to assign empty array rather than using undefined
