### PR TITLE
feat: rename proposed name to "Bitcoin"

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "0.7.0",
   "description": "Manage Bitcoin using MetaMask",
-  "proposedName": "Bitcoin Manager",
+  "proposedName": "Bitcoin",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"


### PR DESCRIPTION
This PR removes the "Manager" part of the Snap's proposed name.

Closes: https://github.com/MetaMask/accounts-planning/issues/640