### PR TITLE
ci(dependabot): add groups for snaps and json-rpc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,10 @@ updates:
     target-branch: 'main'
     versioning-strategy: 'increase-if-necessary'
     open-pull-requests-limit: 10
+    groups:
+      snaps:
+        patterns:
+          - '@metamask/snaps-*'
+      json-rpc:
+        patterns:
+          - '@metamask/json-rpc-*'


### PR DESCRIPTION
This will group some bumps of dependencies together. Resulting in less dependabot PRs in the future!