### PR TITLE
ci(dependabot): ignore major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       time: '06:00'
     allow:
       - dependency-name: '@metamask/*'
+    ignore:
+      - dependency-name: '@metamask/*'
+        update-types: ["version-update:semver-major"]
     target-branch: 'main'
     versioning-strategy: 'increase-if-necessary'
     open-pull-requests-limit: 10


### PR DESCRIPTION
Major bumps should be done manually and only when required. They generally introduce breaking changes and require manual interventions, so this kind of PRs "pollute" the PR list.

Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore