### PR TITLE
feat!: make transactions replaceable by default

### DIFF
--- a/packages/snap/src/bitcoin/wallet/wallet.test.ts
+++ b/packages/snap/src/bitcoin/wallet/wallet.test.ts
@@ -248,7 +248,7 @@ describe('BtcWallet', () => {
       }
     });
 
-    it('uses `replaceable = false` if not provided', async () => {
+    it('uses `replaceable = true` if not provided', async () => {
       const network = networks.testnet;
       const { instance } = createMockDeriver(network);
       const wallet = new BtcWallet(instance, network);
@@ -269,7 +269,7 @@ describe('BtcWallet', () => {
 
       expect(psbtSpy).toHaveBeenCalledWith(
         expect.any(Array<TxInput>),
-        false,
+        true,
         expect.any(String),
         expect.any(Buffer),
         expect.any(Buffer),

--- a/packages/snap/src/bitcoin/wallet/wallet.ts
+++ b/packages/snap/src/bitcoin/wallet/wallet.ts
@@ -140,7 +140,7 @@ export class BtcWallet {
     const psbtService = new PsbtService(this._network);
     psbtService.addInputs(
       selectionResult.inputs,
-      options.replaceable ?? false,
+      options.replaceable ?? true,
       hdPath,
       hexToBuffer(pubkey, false),
       hexToBuffer(mfp, false),


### PR DESCRIPTION
**BREAKING:** This changes the default behavior of the `sendmany` (which will be renamed to `sendBitcoin`) to allow transactions to be replaceable by default.

Issue: https://github.com/MetaMask/accounts-planning/issues/641