### PR TITLE
fix: use input props

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "JyhT1mBhHdij1Ux2wDkKMAPwI2vTys9tmwSXPH7TTAU=",
+    "shasum": "38qGseoO2gGSYQWOm+NcTXmXePq6hjGpz215nIR1LK4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -40,19 +40,11 @@
     },
     "snap_getBip32Entropy": [
       {
-        "path": [
-          "m",
-          "84'",
-          "0'"
-        ],
+        "path": ["m", "84'", "0'"],
         "curve": "secp256k1"
       },
       {
-        "path": [
-          "m",
-          "84'",
-          "1'"
-        ],
+        "path": ["m", "84'", "1'"],
         "curve": "secp256k1"
       }
     ],

--- a/packages/snap/src/ui/components/SendForm.tsx
+++ b/packages/snap/src/ui/components/SendForm.tsx
@@ -114,6 +114,9 @@ export const SendForm: SnapComponent<SendFormProps> = ({
         </Box>
         <Input
           name={SendFormNames.Amount}
+          type="number"
+          min={0}
+          step={0.00000001}
           placeholder="Enter amount to send"
           value={amountToDisplay}
         />


### PR DESCRIPTION
This pr uses the new props thats available from the `@metamask/snaps-sdk`