### PR TITLE
feat: add `hideSnapBranding` when building

### DIFF
--- a/packages/snap/scripts/build-preinstalled-snap.js
+++ b/packages/snap/scripts/build-preinstalled-snap.js
@@ -54,6 +54,7 @@ const preinstalledSnap = {
     },
   ],
   removable: false,
+  hideSnapBranding: true,
 };
 
 // Write preinstalled-snap file


### PR DESCRIPTION
This is required to have the native look-and-feel on the extension with this Snap.