### PR TITLE
refactor: update incorrect CAIP number for BTC asset

### DIFF
--- a/packages/snap/src/bitcoin/chain/service.test.ts
+++ b/packages/snap/src/bitcoin/chain/service.test.ts
@@ -6,7 +6,7 @@ import {
   generateFormattedUtxos,
   generateQuickNodeSendRawTransactionResp,
 } from '../../../test/utils';
-import { Caip2Asset } from '../../constants';
+import { Caip19Asset } from '../../constants';
 import { FeeRate, TransactionStatus } from './constants';
 import type { IDataClient } from './data-client';
 import { BtcOnChainServiceError } from './exceptions';
@@ -73,13 +73,13 @@ describe('BtcOnChainService', () => {
         }, {}),
       );
 
-      const result = await txService.getBalances(addresses, [Caip2Asset.TBtc]);
+      const result = await txService.getBalances(addresses, [Caip19Asset.TBtc]);
 
       expect(getBalanceSpy).toHaveBeenCalledWith(addresses);
 
       Object.values(result.balances).forEach((assetBalances) => {
         expect(assetBalances).toStrictEqual({
-          [Caip2Asset.TBtc]: {
+          [Caip19Asset.TBtc]: {
             amount: BigInt(100),
           },
         });
@@ -93,7 +93,7 @@ describe('BtcOnChainService', () => {
       const addresses = accounts.map((account) => account.address);
 
       await expect(
-        txService.getBalances(addresses, [Caip2Asset.TBtc, Caip2Asset.Btc]),
+        txService.getBalances(addresses, [Caip19Asset.TBtc, Caip19Asset.Btc]),
       ).rejects.toThrow('Only one asset is supported');
     });
 
@@ -104,7 +104,7 @@ describe('BtcOnChainService', () => {
       const addresses = accounts.map((account) => account.address);
 
       await expect(
-        txService.getBalances(addresses, [Caip2Asset.Btc]),
+        txService.getBalances(addresses, [Caip19Asset.Btc]),
       ).rejects.toThrow('Invalid asset');
     });
 
@@ -118,7 +118,7 @@ describe('BtcOnChainService', () => {
       const addresses = accounts.map((account) => account.address);
 
       await expect(
-        txService.getBalances(addresses, [Caip2Asset.TBtc]),
+        txService.getBalances(addresses, [Caip19Asset.TBtc]),
       ).rejects.toThrow('Invalid asset');
     });
   });

--- a/packages/snap/src/bitcoin/chain/service.ts
+++ b/packages/snap/src/bitcoin/chain/service.ts
@@ -1,7 +1,7 @@
 import type { Network } from 'bitcoinjs-lib';
 import { networks } from 'bitcoinjs-lib';
 
-import { Caip2Asset } from '../../constants';
+import { Caip19Asset } from '../../constants';
 import { compactError } from '../../utils';
 import type { FeeRate, TransactionStatus } from './constants';
 import type { IDataClient } from './data-client';
@@ -83,12 +83,12 @@ export class BtcOnChainService {
         throw new BtcOnChainServiceError('Only one asset is supported');
       }
 
-      const allowedAssets = new Set<string>(Object.values(Caip2Asset));
+      const allowedAssets = new Set<string>(Object.values(Caip19Asset));
 
       if (
         !allowedAssets.has(assets[0]) ||
-        (this.network === networks.testnet && assets[0] !== Caip2Asset.TBtc) ||
-        (this.network === networks.bitcoin && assets[0] !== Caip2Asset.Btc)
+        (this.network === networks.testnet && assets[0] !== Caip19Asset.TBtc) ||
+        (this.network === networks.bitcoin && assets[0] !== Caip19Asset.Btc)
       ) {
         throw new BtcOnChainServiceError('Invalid asset');
       }

--- a/packages/snap/src/config.ts
+++ b/packages/snap/src/config.ts
@@ -1,5 +1,5 @@
 import { FeeRate } from './bitcoin/chain/constants';
-import { Caip2ChainId, Caip2Asset } from './constants';
+import { Caip2ChainId, Caip19Asset } from './constants';
 
 export type SnapChainConfig = {
   onChainService: {
@@ -41,7 +41,7 @@ export const Config: SnapChainConfig = {
     defaultAccountType: 'bip122:p2wpkh',
   },
   availableNetworks: Object.values(Caip2ChainId),
-  availableAssets: Object.values(Caip2Asset),
+  availableAssets: Object.values(Caip19Asset),
   defaultFeeRate: FeeRate.Medium,
   unit: 'BTC',
   explorer: {

--- a/packages/snap/src/constants.ts
+++ b/packages/snap/src/constants.ts
@@ -5,7 +5,7 @@ export enum Caip2ChainId {
   Testnet = 'bip122:000000000933ea01ad0ee984209779ba',
 }
 
-export enum Caip2Asset {
+export enum Caip19Asset {
   Btc = 'bip122:000000000019d6689c085ae165831e93/slip44:0',
   TBtc = 'bip122:000000000933ea01ad0ee984209779ba/slip44:0',
 }

--- a/packages/snap/src/keyring.test.ts
+++ b/packages/snap/src/keyring.test.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { generateAccounts } from '../test/utils';
 import { BtcAccount, BtcWallet, ScriptType } from './bitcoin/wallet';
 import { Config } from './config';
-import { Caip2Asset, Caip2ChainId } from './constants';
+import { Caip19Asset, Caip2ChainId } from './constants';
 import { AccountNotFoundError, MethodNotImplementedError } from './exceptions';
 import { Factory } from './factory';
 import type { CreateAccountOptions } from './keyring';
@@ -356,7 +356,7 @@ describe('BtcKeyring', () => {
         txId: 'txid',
       });
       getBalanceRpcSpy.mockResolvedValue({
-        [Caip2Asset.TBtc]: {
+        [Caip19Asset.TBtc]: {
           amount: '1',
           unit: Config.unit,
         },
@@ -523,7 +523,7 @@ describe('BtcKeyring', () => {
         hdPath: sender.hdPath,
       });
 
-      const assets = [Caip2Asset.TBtc];
+      const assets = [Caip19Asset.TBtc];
       const expectedResp = assets.reduce((acc, asset) => {
         acc[asset] = {
           amount: '1',
@@ -534,7 +534,7 @@ describe('BtcKeyring', () => {
 
       getBalanceRpcSpy.mockResolvedValue(expectedResp);
 
-      await keyring.getAccountBalances(keyringAccount.id, [Caip2Asset.TBtc]);
+      await keyring.getAccountBalances(keyringAccount.id, [Caip19Asset.TBtc]);
 
       expect(getBalanceRpcSpy).toHaveBeenCalledWith(expect.any(BtcAccount), {
         scope: caip2ChainId,
@@ -549,7 +549,7 @@ describe('BtcKeyring', () => {
       const account = generateAccounts(1)[0];
 
       await expect(
-        keyring.getAccountBalances(account.id, [Caip2Asset.TBtc]),
+        keyring.getAccountBalances(account.id, [Caip19Asset.TBtc]),
       ).rejects.toThrow(Error);
     });
   });

--- a/packages/snap/src/rpcs/__tests__/helper.ts
+++ b/packages/snap/src/rpcs/__tests__/helper.ts
@@ -9,7 +9,7 @@ import type { Utxo } from '../../bitcoin/chain';
 import { BtcOnChainService } from '../../bitcoin/chain';
 import type { BtcAccount, BtcWallet } from '../../bitcoin/wallet';
 import { Config } from '../../config';
-import { Caip2Asset } from '../../constants';
+import { Caip19Asset } from '../../constants';
 import { Factory } from '../../factory';
 import type { SendFlowRequest } from '../../stateManagement';
 import { KeyringStateManager } from '../../stateManagement';
@@ -471,10 +471,10 @@ export class StartSendTransactionFlowTest extends SendBitcoinTest {
     this.getBalancesSpy.mockResolvedValue({
       balances: {
         [this.keyringAccount.address]: {
-          [Caip2Asset.TBtc]: {
+          [Caip19Asset.TBtc]: {
             amount: '100000000',
           },
-          [Caip2Asset.Btc]: {
+          [Caip19Asset.Btc]: {
             amount: '100000000',
           },
         },
@@ -488,10 +488,10 @@ export class StartSendTransactionFlowTest extends SendBitcoinTest {
       },
       balances: {
         value: {
-          [Caip2Asset.TBtc]: {
+          [Caip19Asset.TBtc]: {
             amount: '1',
           },
-          [Caip2Asset.Btc]: {
+          [Caip19Asset.Btc]: {
             amount: '1',
           },
           error: '',

--- a/packages/snap/src/rpcs/get-rates-and-balances.ts
+++ b/packages/snap/src/rpcs/get-rates-and-balances.ts
@@ -1,10 +1,10 @@
 import type { BtcAccount } from '../bitcoin/wallet';
-import type { Caip2Asset } from '../constants';
+import type { Caip19Asset } from '../constants';
 import { getRates } from '../utils/rates';
 import { getBalances } from './get-balances';
 
 export type GetRatesAndBalancesParams = {
-  asset: Caip2Asset;
+  asset: Caip19Asset;
   scope: string;
   btcAccount: BtcAccount;
 };

--- a/packages/snap/src/rpcs/start-send-transaction-flow.test.ts
+++ b/packages/snap/src/rpcs/start-send-transaction-flow.test.ts
@@ -1,4 +1,4 @@
-import { Caip2Asset, Caip2ChainId } from '../constants';
+import { Caip19Asset, Caip2ChainId } from '../constants';
 import {
   AccountNotFoundError,
   SendFlowRequestNotFoundError,
@@ -47,8 +47,8 @@ describe('startSendTransactionFlow', () => {
     getBalanceAndRatesSpy.mockResolvedValue({
       balances: {
         value: {
-          [Caip2Asset.Btc]: { amount: '1' },
-          [Caip2Asset.TBtc]: { amount: '1' },
+          [Caip19Asset.Btc]: { amount: '1' },
+          [Caip19Asset.TBtc]: { amount: '1' },
         },
         error: '',
       },
@@ -116,8 +116,8 @@ describe('startSendTransactionFlow', () => {
     getBalanceAndRatesSpy.mockResolvedValue({
       balances: {
         value: {
-          [Caip2Asset.Btc]: { amount: '1' },
-          [Caip2Asset.TBtc]: { amount: '1' },
+          [Caip19Asset.Btc]: { amount: '1' },
+          [Caip19Asset.TBtc]: { amount: '1' },
         },
         error: '',
       },
@@ -189,8 +189,8 @@ describe('startSendTransactionFlow', () => {
     getBalanceAndRatesSpy.mockResolvedValue({
       balances: {
         value: {
-          [Caip2Asset.Btc]: { amount: '1' },
-          [Caip2Asset.TBtc]: { amount: '1' },
+          [Caip19Asset.Btc]: { amount: '1' },
+          [Caip19Asset.TBtc]: { amount: '1' },
         },
         error: '',
       },

--- a/packages/snap/src/ui/utils.ts
+++ b/packages/snap/src/ui/utils.ts
@@ -4,7 +4,7 @@ import validate, { Network } from 'bitcoin-address-validation';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
-  Caip2Asset,
+  Caip19Asset,
   Caip2ChainId,
   Caip2ChainIdToNetworkName,
 } from '../constants';
@@ -339,8 +339,8 @@ export async function sendBitcoinParamsToSendFlowParams(
  * @param scope - The scope of the network (mainnet or testnet).
  * @returns The asset type corresponding to the scope.
  */
-export function getAssetTypeFromScope(scope: string): Caip2Asset {
-  return scope === Caip2ChainId.Mainnet ? Caip2Asset.Btc : Caip2Asset.TBtc;
+export function getAssetTypeFromScope(scope: string): Caip19Asset {
+  return scope === Caip2ChainId.Mainnet ? Caip19Asset.Btc : Caip19Asset.TBtc;
 }
 
 /**

--- a/packages/snap/src/utils/rates.ts
+++ b/packages/snap/src/utils/rates.ts
@@ -1,8 +1,8 @@
-import type { Caip2Asset } from '../constants';
+import type { Caip19Asset } from '../constants';
 import { CurrencyRatesNotAvailableError } from '../exceptions';
 import { getRatesFromMetamask } from './snap';
 
-export const getRates = async (_asset: Caip2Asset): Promise<string> => {
+export const getRates = async (_asset: Caip19Asset): Promise<string> => {
   // _asset is not used because the only supported asset is 'btc' for now.
   const ratesResult = await getRatesFromMetamask('btc');
 


### PR DESCRIPTION
This PR is to update incorrect CAIP number for BTC asset
- it was Caip2Asset
- it should be Caip19Asset

reference: https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-19.md