### PR TITLE
ci: allow release workflow for hotfix/* branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@ name: Main
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'hotfix/*'
   pull_request:
   merge_group:
 


### PR DESCRIPTION
We need to create a hotfix for the Snap. Unfortunately this is hard to do manually for now, so as a workaround we're gonna use the following procedure:

1. Create a `hotfix/<version>` branch
2. Cherry-pick/Adds the required changes into this branch
3. Try to create a release branch deriving from that `hotfix/<version>` branch
4. Update the base branch for the release PR to use the `hotfix/<version> branch
5. Merge the PR and triggers the release workflow from it

Hopefully this would work as intended.