### PR TITLE
chore: revert commit `13171a5` (ci: allow release workflow for hotfix/* branches (#326))

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,7 @@ name: Main
 
 on:
   push:
-    branches:
-      - main
-      - 'hotfix/*'
+    branches: [main]
   pull_request:
   merge_group:
 


### PR DESCRIPTION
This reverts commit 13171a5ac97f439adbf013d50e18a67cf41f77c6.