### PR TITLE
fix: update transaction time to 30 min

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "vmePCqA6i2v0k+TUWn66ik83antn2ZI9MoyChuecbew=",
+    "shasum": "oHTF4iRO8Irnq6sCRT4GqqLnj2CufU0AfwbGHO7DBM8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/ui/components/TransactionSummary.tsx
+++ b/packages/snap/src/ui/components/TransactionSummary.tsx
@@ -63,7 +63,7 @@ export const TransactionSummary: SnapComponent<TransactionSummaryProps> = ({
         />
       </Row>
       <Row label="Transaction speed" tooltip="The estimated time of the TX">
-        <Text>30m</Text>
+        <Text>30 min</Text>
       </Row>
       <Row label="Total">
         <Value


### PR DESCRIPTION
This PR updates the copy from `30m` to `30 min`

Resolves: https://github.com/MetaMask/accounts-planning/issues/659