### PR TITLE
fix: locale upload path

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,6 +8,6 @@
   [
     {
       'source': 'packages/snap/locales/en.json',
-      'translation': 'locales/%locale%.json',
+      'translation': 'packages/snap/locales/%locale%.json',
     },
   ]


### PR DESCRIPTION
This pr fixes the upload path that crowdin uses for translations.