### PR TITLE
feat: multi account support

### DIFF
--- a/packages/snap/integration-test/keyring.test.ts
+++ b/packages/snap/integration-test/keyring.test.ts
@@ -112,6 +112,26 @@ describe('Keyring', () => {
     }
   });
 
+  it('creates account by derivationPath idempotently', async () => {
+    snap.mockJsonRpc({ method: 'snap_manageAccounts', result: {} });
+
+    const response = await snap.onKeyringRequest({
+      origin: ORIGIN,
+      method: 'keyring_createAccount',
+      params: {
+        options: {
+          scope: BtcScope.Mainnet,
+          addressType: Caip2AddressType.P2wpkh,
+          derivationPath: "m/84'/0'/1'",
+        },
+      },
+    });
+
+    expect(response).toRespondWith(
+      accounts[`${Caip2AddressType.P2wpkh}:${BtcScope.Mainnet}:1`],
+    );
+  });
+
   it('returns the same account if already exists', async () => {
     snap.mockJsonRpc({ method: 'snap_manageAccounts', result: {} });
 

--- a/packages/snap/integration-test/keyring.test.ts
+++ b/packages/snap/integration-test/keyring.test.ts
@@ -24,42 +24,57 @@ describe('Keyring', () => {
       // Main account used in the tests, only one to synchronize
       addressType: Caip2AddressType.P2wpkh,
       scope: BtcScope.Regtest,
+      index: 0,
       expectedAddress: TEST_ADDRESS,
       synchronize: true,
     },
     {
       addressType: Caip2AddressType.P2wpkh,
       scope: BtcScope.Mainnet,
+      index: 0,
       expectedAddress: 'bc1q832zlt4tgnqy88vd20mazw77dlt0j0wf2naw8q',
+      synchronize: false,
+    },
+    {
+      // Tests multiple accounts of same address type
+      addressType: Caip2AddressType.P2wpkh,
+      scope: BtcScope.Mainnet,
+      index: 1,
+      expectedAddress: 'bc1qe2e3tdkqwytw7furyl2nlfy3sqs23acynn50d9',
       synchronize: false,
     },
     {
       addressType: Caip2AddressType.P2pkh,
       scope: BtcScope.Mainnet,
+      index: 0,
       expectedAddress: '15feVv7kK3z7jxA4RZZzY7Fwdu3yqFwzcT',
       synchronize: false,
     },
     {
       addressType: Caip2AddressType.P2pkh,
       scope: BtcScope.Testnet,
+      index: 0,
       expectedAddress: 'mjPQaLkhZN3MxsYN8Nebzwevuz8vdTaRCq',
       synchronize: false,
     },
     {
       addressType: Caip2AddressType.P2sh,
       scope: BtcScope.Mainnet,
+      index: 0,
       expectedAddress: '3QVSaDYjxEh4L3K24eorrQjfVxPAKJMys2',
       synchronize: false,
     },
     {
       addressType: Caip2AddressType.P2sh,
       scope: BtcScope.Testnet,
+      index: 0,
       expectedAddress: '2NBG623WvXp1zxKB6gK2mnMe2mSDCur5qRU',
       synchronize: false,
     },
     {
       addressType: Caip2AddressType.P2tr,
       scope: BtcScope.Mainnet,
+      index: 0,
       expectedAddress:
         'bc1p4rue37y0v9snd4z3fvw43d29u97qxf9j3fva72xy2t7hekg24dzsaz40mz',
       synchronize: false,
@@ -67,6 +82,7 @@ describe('Keyring', () => {
     {
       addressType: Caip2AddressType.P2tr,
       scope: BtcScope.Testnet,
+      index: 0,
       expectedAddress:
         'tb1pwwjax3vpq6h69965hcr22vkpm4qdvyu2pz67wyj8eagp9vxkcz0q0ya20h',
       synchronize: false,
@@ -90,8 +106,9 @@ describe('Keyring', () => {
     });
 
     if ('result' in response.response) {
-      accounts[`${requestOpts.addressType}:${requestOpts.scope}`] = response
-        .response.result as KeyringAccount;
+      accounts[
+        `${requestOpts.addressType}:${requestOpts.scope}:${requestOpts.index}`
+      ] = response.response.result as KeyringAccount;
     }
   });
 
@@ -110,7 +127,7 @@ describe('Keyring', () => {
     });
 
     expect(response).toRespondWith(
-      accounts[`${Caip2AddressType.P2wpkh}:${BtcScope.Mainnet}`],
+      accounts[`${Caip2AddressType.P2wpkh}:${BtcScope.Mainnet}:0`],
     );
   });
 
@@ -119,12 +136,12 @@ describe('Keyring', () => {
       origin: ORIGIN,
       method: 'keyring_getAccount',
       params: {
-        id: accounts[`${Caip2AddressType.P2wpkh}:${BtcScope.Mainnet}`].id,
+        id: accounts[`${Caip2AddressType.P2wpkh}:${BtcScope.Mainnet}:0`].id,
       },
     });
 
     expect(response).toRespondWith(
-      accounts[`${Caip2AddressType.P2wpkh}:${BtcScope.Mainnet}`],
+      accounts[`${Caip2AddressType.P2wpkh}:${BtcScope.Mainnet}:0`],
     );
   });
 
@@ -139,7 +156,7 @@ describe('Keyring', () => {
 
   it('lists account transactions', async () => {
     const accoundId =
-      accounts[`${Caip2AddressType.P2wpkh}:${BtcScope.Regtest}`].id;
+      accounts[`${Caip2AddressType.P2wpkh}:${BtcScope.Regtest}:0`].id;
     const response = await snap.onKeyringRequest({
       origin: ORIGIN,
       method: 'keyring_listAccountTransactions',
@@ -160,7 +177,7 @@ describe('Keyring', () => {
       origin: ORIGIN,
       method: 'keyring_getAccountBalances',
       params: {
-        id: accounts[`${Caip2AddressType.P2wpkh}:${BtcScope.Regtest}`].id,
+        id: accounts[`${Caip2AddressType.P2wpkh}:${BtcScope.Regtest}:0`].id,
         assets: [Caip19Asset.Regtest],
       },
     });
@@ -174,7 +191,7 @@ describe('Keyring', () => {
   });
 
   it('removes an account', async () => {
-    const { id } = accounts[`${Caip2AddressType.P2pkh}:${BtcScope.Mainnet}`];
+    const { id } = accounts[`${Caip2AddressType.P2pkh}:${BtcScope.Mainnet}:0`];
 
     let response = await snap.onKeyringRequest({
       origin: ORIGIN,
@@ -224,7 +241,7 @@ describe('Keyring', () => {
         origin: ORIGIN,
         method: 'keyring_listAccountAssets',
         params: {
-          id: accounts[`${addressType}:${scope}`].id,
+          id: accounts[`${addressType}:${scope}:0`].id,
         },
       });
 

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "KCAk/gika7mx88LOjO4qhMMHH/SK+5wai2EMWMM031E=",
+    "shasum": "UJXkasCHOMkLs1Y58OMY7bZzANomv7gxoYnP9kxX6mw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/config.ts
+++ b/packages/snap/src/config.ts
@@ -8,7 +8,6 @@ export const Config: SnapConfig = {
   logLevel: (process.env.LOG_LEVEL ?? LogLevel.INFO) as LogLevel,
   encrypt: false,
   accounts: {
-    index: 0,
     defaultAddressType: (process.env.DEFAULT_ADDRESS_TYPE ??
       'p2wpkh') as AddressType,
   },

--- a/packages/snap/src/entities/account.ts
+++ b/packages/snap/src/entities/account.ts
@@ -222,3 +222,31 @@ export type BitcoinAccountRepository = {
    */
   getFrozenUTXOs(id: string): Promise<string[]>;
 };
+
+export enum Purpose {
+  Legacy = 44,
+  Segwit = 49,
+  NativeSegwit = 84,
+  Taproot = 86,
+  Multisig = 45,
+}
+export enum Slip44 {
+  Bitcoin = 0,
+  Testnet = 1,
+}
+
+export const addressTypeToPurpose: Record<AddressType, Purpose> = {
+  p2pkh: Purpose.Legacy,
+  p2sh: Purpose.Segwit,
+  p2wsh: Purpose.Multisig,
+  p2wpkh: Purpose.NativeSegwit,
+  p2tr: Purpose.Taproot,
+};
+
+export const networkToCoinType: Record<Network, Slip44> = {
+  bitcoin: Slip44.Bitcoin,
+  testnet: Slip44.Testnet,
+  testnet4: Slip44.Testnet,
+  signet: Slip44.Testnet,
+  regtest: Slip44.Testnet,
+};

--- a/packages/snap/src/entities/config.ts
+++ b/packages/snap/src/entities/config.ts
@@ -15,7 +15,6 @@ export type SnapConfig = {
 };
 
 export type AccountsConfig = {
-  index: number;
   defaultAddressType: AddressType;
 };
 

--- a/packages/snap/src/handlers/KeyringHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringHandler.test.ts
@@ -62,6 +62,7 @@ describe('KeyringHandler', () => {
 
   describe('createAccount', () => {
     const entropySource = 'some-source';
+    const index = 1;
     const correlationId = 'correlation-id';
 
     it('respects provided params', async () => {
@@ -69,6 +70,7 @@ describe('KeyringHandler', () => {
       const options = {
         scope: BtcScope.Signet,
         entropySource,
+        index,
         addressType: Caip2AddressType.P2pkh,
         metamask: {
           correlationId,
@@ -80,6 +82,7 @@ describe('KeyringHandler', () => {
       expect(mockAccounts.create).toHaveBeenCalledWith(
         caip2ToNetwork[BtcScope.Signet],
         entropySource,
+        index,
         caip2ToAddressType[Caip2AddressType.P2pkh],
         correlationId,
       );
@@ -90,7 +93,7 @@ describe('KeyringHandler', () => {
       mockAccounts.create.mockResolvedValue(mockAccount);
       const options = {
         scope: BtcScope.Signet,
-        entropySourceId: entropySource,
+        entropySource,
         addressType: Caip2AddressType.P2pkh,
         synchronize: true,
       };

--- a/packages/snap/src/handlers/KeyringHandler.ts
+++ b/packages/snap/src/handlers/KeyringHandler.ts
@@ -13,7 +13,15 @@ import type {
 } from '@metamask/keyring-api';
 import { handleKeyringRequest } from '@metamask/keyring-snap-sdk';
 import type { Json, JsonRpcRequest } from '@metamask/utils';
-import { assert, boolean, enums, object, optional, string } from 'superstruct';
+import {
+  assert,
+  boolean,
+  enums,
+  number,
+  object,
+  optional,
+  string,
+} from 'superstruct';
 
 import { networkToCurrencyUnit } from '../entities';
 import type { AccountUseCases } from '../use-cases/AccountUseCases';
@@ -34,6 +42,7 @@ export const CreateAccountRequest = object({
   entropySource: optional(string()),
   accountNameSuggestion: optional(string()),
   synchronize: optional(boolean()),
+  index: optional(number()),
   ...MetaMaskOptionsStruct.schema,
 });
 
@@ -72,6 +81,7 @@ export class KeyringHandler implements Keyring {
     const account = await this.#accountsUseCases.create(
       caip2ToNetwork[opts.scope],
       opts.entropySource,
+      opts.index,
       opts.addressType ? caip2ToAddressType[opts.addressType] : undefined,
       opts.metamask?.correlationId,
     );

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -121,13 +121,13 @@ describe('AccountUseCases', () => {
       async ({ tAddressType, purpose }) => {
         const derivationPath = [entropySource, purpose, "0'", `${index}'`];
 
-        await useCases.create(
+        await useCases.create({
           network,
           entropySource,
           index,
-          tAddressType,
+          addressType: tAddressType,
           correlationId,
-        );
+        });
 
         expect(mockRepository.getByDerivationPath).toHaveBeenCalledWith(
           derivationPath,
@@ -160,13 +160,13 @@ describe('AccountUseCases', () => {
           `${index}'`,
         ];
 
-        await useCases.create(
-          tNetwork,
+        await useCases.create({
+          network: tNetwork,
           entropySource,
           index,
           addressType,
           correlationId,
-        );
+        });
 
         expect(mockRepository.getByDerivationPath).toHaveBeenCalledWith(
           expectedDerivationPath,
@@ -187,12 +187,12 @@ describe('AccountUseCases', () => {
       const mockExistingAccount = mock<BitcoinAccount>();
       mockRepository.getByDerivationPath.mockResolvedValue(mockExistingAccount);
 
-      const result = await useCases.create(
+      const result = await useCases.create({
         network,
         entropySource,
         index,
         addressType,
-      );
+      });
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
       expect(mockRepository.insert).not.toHaveBeenCalled();
@@ -204,12 +204,12 @@ describe('AccountUseCases', () => {
     it('creates a new account if one does not exist', async () => {
       mockRepository.getByDerivationPath.mockResolvedValue(null);
 
-      const result = await useCases.create(
+      const result = await useCases.create({
         network,
         entropySource,
         index,
         addressType,
-      );
+      });
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
       expect(mockRepository.insert).toHaveBeenCalled();
@@ -223,7 +223,7 @@ describe('AccountUseCases', () => {
       mockRepository.getByDerivationPath.mockRejectedValue(error);
 
       await expect(
-        useCases.create(network, entropySource, index, addressType),
+        useCases.create({ network, entropySource, index, addressType }),
       ).rejects.toBe(error);
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
@@ -237,7 +237,7 @@ describe('AccountUseCases', () => {
       mockRepository.insert.mockRejectedValue(error);
 
       await expect(
-        useCases.create(network, entropySource, index, addressType),
+        useCases.create({ network, entropySource, index, addressType }),
       ).rejects.toBe(error);
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
@@ -251,7 +251,7 @@ describe('AccountUseCases', () => {
       mockSnapClient.emitAccountCreatedEvent.mockRejectedValue(error);
 
       await expect(
-        useCases.create(network, entropySource, index, addressType),
+        useCases.create({ network, entropySource, index, addressType }),
       ).rejects.toBe(error);
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -27,7 +27,6 @@ describe('AccountUseCases', () => {
   const mockChain = mock<BlockchainClient>();
   const mockMetaProtocols = mock<MetaProtocolsClient>();
   const accountsConfig: AccountsConfig = {
-    index: 0,
     defaultAddressType: 'p2wpkh',
   };
 
@@ -102,6 +101,7 @@ describe('AccountUseCases', () => {
     const network: Network = 'bitcoin';
     const addressType: AddressType = 'p2wpkh';
     const entropySource = 'some-source';
+    const index = 1;
     const correlationId = 'some-correlation-id';
 
     const mockAccount = mock<BitcoinAccount>();
@@ -119,16 +119,12 @@ describe('AccountUseCases', () => {
     ] as { tAddressType: AddressType; purpose: string }[])(
       'creates an account of type: %s',
       async ({ tAddressType, purpose }) => {
-        const derivationPath = [
-          entropySource,
-          purpose,
-          "0'",
-          `${accountsConfig.index}'`,
-        ];
+        const derivationPath = [entropySource, purpose, "0'", `${index}'`];
 
         await useCases.create(
           network,
           entropySource,
+          index,
           tAddressType,
           correlationId,
         );
@@ -161,12 +157,13 @@ describe('AccountUseCases', () => {
           entropySource,
           "84'",
           coinType,
-          `${accountsConfig.index}'`,
+          `${index}'`,
         ];
 
         await useCases.create(
           tNetwork,
           entropySource,
+          index,
           addressType,
           correlationId,
         );
@@ -190,7 +187,12 @@ describe('AccountUseCases', () => {
       const mockExistingAccount = mock<BitcoinAccount>();
       mockRepository.getByDerivationPath.mockResolvedValue(mockExistingAccount);
 
-      const result = await useCases.create(network, entropySource, addressType);
+      const result = await useCases.create(
+        network,
+        entropySource,
+        index,
+        addressType,
+      );
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
       expect(mockRepository.insert).not.toHaveBeenCalled();
@@ -202,7 +204,12 @@ describe('AccountUseCases', () => {
     it('creates a new account if one does not exist', async () => {
       mockRepository.getByDerivationPath.mockResolvedValue(null);
 
-      const result = await useCases.create(network, entropySource, addressType);
+      const result = await useCases.create(
+        network,
+        entropySource,
+        index,
+        addressType,
+      );
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
       expect(mockRepository.insert).toHaveBeenCalled();
@@ -216,7 +223,7 @@ describe('AccountUseCases', () => {
       mockRepository.getByDerivationPath.mockRejectedValue(error);
 
       await expect(
-        useCases.create(network, entropySource, addressType),
+        useCases.create(network, entropySource, index, addressType),
       ).rejects.toBe(error);
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
@@ -230,7 +237,7 @@ describe('AccountUseCases', () => {
       mockRepository.insert.mockRejectedValue(error);
 
       await expect(
-        useCases.create(network, entropySource, addressType),
+        useCases.create(network, entropySource, index, addressType),
       ).rejects.toBe(error);
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
@@ -244,7 +251,7 @@ describe('AccountUseCases', () => {
       mockSnapClient.emitAccountCreatedEvent.mockRejectedValue(error);
 
       await expect(
-        useCases.create(network, entropySource, addressType),
+        useCases.create(network, entropySource, index, addressType),
       ).rejects.toBe(error);
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();

--- a/packages/snap/src/use-cases/AccountUseCases.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.ts
@@ -86,6 +86,7 @@ export class AccountUseCases {
   async create(
     network: Network,
     entropySource?: string,
+    index = 0,
     addressType: AddressType = this.#accountConfig.defaultAddressType,
     correlationId?: string,
   ): Promise<BitcoinAccount> {
@@ -93,6 +94,7 @@ export class AccountUseCases {
       network,
       addressType,
       entropySource,
+      index,
       correlationId,
     });
 
@@ -100,7 +102,7 @@ export class AccountUseCases {
       entropySource ?? 'm',
       addressTypeToPurpose[addressType],
       networkToCoinType[network],
-      `${this.#accountConfig.index}'`,
+      `${index}'`,
     ];
 
     // Idempotent account creation + ensures only one account per derivation path

--- a/packages/snap/src/use-cases/AccountUseCases.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.ts
@@ -7,30 +7,24 @@ import type {
 } from '@metamask/bitcoindevkit';
 import { getCurrentUnixTimestamp } from '@metamask/keyring-snap-sdk';
 
-import type {
-  AccountsConfig,
-  BitcoinAccount,
-  BitcoinAccountRepository,
-  BlockchainClient,
-  SnapClient,
-  MetaProtocolsClient,
-  Logger,
+import {
+  type AccountsConfig,
+  type BitcoinAccount,
+  type BitcoinAccountRepository,
+  type BlockchainClient,
+  type SnapClient,
+  type MetaProtocolsClient,
+  type Logger,
+  addressTypeToPurpose,
+  networkToCoinType,
 } from '../entities';
 
-const addressTypeToPurpose: Record<AddressType, string> = {
-  p2pkh: "44'",
-  p2sh: "49'",
-  p2wsh: "45'",
-  p2wpkh: "84'",
-  p2tr: "86'",
-};
-
-const networkToCoinType: Record<Network, string> = {
-  bitcoin: "0'",
-  testnet: "1'",
-  testnet4: "1'",
-  signet: "1'",
-  regtest: "1'",
+export type CreateAccountParams = {
+  network: Network;
+  index?: number;
+  entropySource?: string;
+  addressType?: AddressType;
+  correlationId?: string;
 };
 
 export class AccountUseCases {
@@ -83,25 +77,20 @@ export class AccountUseCases {
     return account;
   }
 
-  async create(
-    network: Network,
-    entropySource?: string,
-    index = 0,
-    addressType: AddressType = this.#accountConfig.defaultAddressType,
-    correlationId?: string,
-  ): Promise<BitcoinAccount> {
-    this.#logger.debug('Creating new Bitcoin account. Params: %o', {
+  async create(req: CreateAccountParams): Promise<BitcoinAccount> {
+    this.#logger.debug('Creating new Bitcoin account. Params: %o', req);
+    const {
+      addressType = this.#accountConfig.defaultAddressType,
+      index = 0,
       network,
-      addressType,
-      entropySource,
-      index,
       correlationId,
-    });
+      entropySource = 'm',
+    } = req;
 
     const derivationPath = [
-      entropySource ?? 'm',
-      addressTypeToPurpose[addressType],
-      networkToCoinType[network],
+      entropySource,
+      `${addressTypeToPurpose[addressType]}'`,
+      `${networkToCoinType[network]}'`,
       `${index}'`,
     ];
 


### PR DESCRIPTION
Supports multiple accounts by `index` or `derivationPath`:
- When a `derivationPath` is provided, use it to derive the `index`.
- If `index` is not provided, assume it's 0.
- Remove default index from config.

Given the high amount of params now to createAccount use case, create a type for it as `CreateAccountParams`.