### PR TITLE
feat: discover accounts

### DIFF
--- a/packages/snap/integration-test/keyring.test.ts
+++ b/packages/snap/integration-test/keyring.test.ts
@@ -21,6 +21,27 @@ describe('Keyring', () => {
     });
   });
 
+  it('discover accounts successfully', async () => {
+    const response = await snap.onKeyringRequest({
+      origin: ORIGIN,
+      method: 'keyring_discoverAccounts',
+      params: {
+        scopes: [BtcScope.Regtest], // avoid using other networks than Regtest as real external calls will be performed
+        entropySource: 'm', // we don't know the real entropy source so "m" acts as the default
+        groupIndex: 0,
+      },
+    });
+
+    // We should get 1 account, the p2wpkh one of Regtest
+    expect(response).toRespondWith([
+      {
+        type: 'bip44',
+        scopes: [BtcScope.Regtest],
+        derivationPath: "m/84'/0'/0'",
+      },
+    ]);
+  });
+
   it.each([
     {
       // Main account used in the tests, only one to synchronize

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
-    "@metamask/bitcoindevkit": "^0.1.8",
+    "@metamask/bitcoindevkit": "^0.1.9",
     "@metamask/key-tree": "^10.1.1",
     "@metamask/keyring-api": "^17.5.0",
     "@metamask/keyring-snap-sdk": "^3.2.0",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "6lmRiw6EHquk8/DyuYmIAJmXIpNW5KN8iVUwxlr+yg0=",
+    "shasum": "vTG5BqOvxrlBoYADKe6Zoo4aKIPbJDZW9mw/XpQePMQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "qK4FfcJ4wdsy2NYI6mrjhvz5uiHb88QwetsmdQ8kD2I=",
+    "shasum": "6lmRiw6EHquk8/DyuYmIAJmXIpNW5KN8iVUwxlr+yg0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "qyd/KD3jfAg7N4Z9V1Gw1KX6416MW6/S+pEaLgqNsKQ=",
+    "shasum": "qK4FfcJ4wdsy2NYI6mrjhvz5uiHb88QwetsmdQ8kD2I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/entities/account.ts
+++ b/packages/snap/src/entities/account.ts
@@ -253,6 +253,7 @@ export enum Purpose {
   Taproot = 86,
   Multisig = 45,
 }
+
 export enum Slip44 {
   Bitcoin = 0,
   Testnet = 1,
@@ -264,6 +265,14 @@ export const addressTypeToPurpose: Record<AddressType, Purpose> = {
   p2wsh: Purpose.Multisig,
   p2wpkh: Purpose.NativeSegwit,
   p2tr: Purpose.Taproot,
+};
+
+export const purposeToAddressType: Record<Purpose, AddressType> = {
+  [Purpose.Legacy]: 'p2pkh',
+  [Purpose.Segwit]: 'p2sh',
+  [Purpose.Multisig]: 'p2wsh',
+  [Purpose.NativeSegwit]: 'p2wpkh',
+  [Purpose.Taproot]: 'p2tr',
 };
 
 export const networkToCoinType: Record<Network, Slip44> = {

--- a/packages/snap/src/handlers/KeyringHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringHandler.test.ts
@@ -208,8 +208,8 @@ describe('KeyringHandler', () => {
       expect(mockAccounts.fullScan).toHaveBeenCalled();
     });
 
-    it('propagates errors from full scan', async () => {
-      const error = new Error('emitEvent error');
+    it('propagates errors from emitAccountCreatedEvent', async () => {
+      const error = new Error('emitAccountCreatedEvent error');
       mockSnapClient.emitAccountCreatedEvent.mockRejectedValue(error);
 
       await expect(

--- a/packages/snap/src/handlers/KeyringHandler.ts
+++ b/packages/snap/src/handlers/KeyringHandler.ts
@@ -25,11 +25,11 @@ import {
   string,
 } from 'superstruct';
 
+import type { SnapClient } from '../entities';
 import {
   networkToCurrencyUnit,
   Purpose,
   purposeToAddressType,
-  SnapClient,
 } from '../entities';
 import {
   networkToCaip19,
@@ -89,9 +89,9 @@ export class KeyringHandler implements Keyring {
   }
 
   async createAccount(
-    opts: Record<string, Json> & MetaMaskOptions,
+    options: Record<string, Json> & MetaMaskOptions,
   ): Promise<KeyringAccount> {
-    assert(opts, CreateAccountRequest);
+    assert(options, CreateAccountRequest);
     const {
       metamask,
       scope,
@@ -100,7 +100,7 @@ export class KeyringHandler implements Keyring {
       derivationPath,
       addressType,
       synchronize,
-    } = opts;
+    } = options;
 
     const resolvedIndex = derivationPath
       ? this.#extractAccountIndex(derivationPath)

--- a/packages/snap/src/handlers/caip.ts
+++ b/packages/snap/src/handlers/caip.ts
@@ -13,7 +13,6 @@ const reverseMapping = <
 export enum Caip2AddressType {
   P2pkh = 'bip122:p2pkh',
   P2sh = 'bip122:p2sh',
-  P2wsh = 'bip122:p2wsh',
   P2wpkh = 'bip122:p2wpkh',
   P2tr = 'bip122:p2tr',
 }
@@ -29,7 +28,6 @@ export const caip2ToNetwork: Record<BtcScope, Network> = {
 export const caip2ToAddressType: Record<Caip2AddressType, AddressType> = {
   [Caip2AddressType.P2pkh]: 'p2pkh',
   [Caip2AddressType.P2sh]: 'p2sh',
-  [Caip2AddressType.P2wsh]: 'p2wsh',
   [Caip2AddressType.P2wpkh]: 'p2wpkh',
   [Caip2AddressType.P2tr]: 'p2tr',
 };

--- a/packages/snap/src/handlers/mappings.ts
+++ b/packages/snap/src/handlers/mappings.ts
@@ -182,11 +182,11 @@ export function mapToTransaction(
 }
 
 /**
- * Maps a Bitcoin Account to a Keyring Account.
+ * Maps a Bitcoin Account to a Discovered Account.
  *
  * @param account - The Bitcoin account.
  * @param groupIndex - The group index.
- * @returns The Keyring account.
+ * @returns The Discovered account.
  */
 export function mapToDiscoveredAccount(
   account: BitcoinAccount,

--- a/packages/snap/src/handlers/mappings.ts
+++ b/packages/snap/src/handlers/mappings.ts
@@ -8,12 +8,22 @@ import type {
   WalletTx,
 } from '@metamask/bitcoindevkit';
 import type {
+  DiscoveredAccount,
   KeyringAccount,
   Transaction as KeyringTransaction,
 } from '@metamask/keyring-api';
-import { TransactionStatus, BtcMethod } from '@metamask/keyring-api';
+import {
+  TransactionStatus,
+  BtcMethod,
+  DiscoveredAccountType,
+} from '@metamask/keyring-api';
 
-import { networkToCurrencyUnit, type BitcoinAccount } from '../entities';
+import {
+  addressTypeToPurpose,
+  networkToCoinType,
+  networkToCurrencyUnit,
+  type BitcoinAccount,
+} from '../entities';
 import type { Caip19Asset } from './caip';
 import { addressTypeToCaip2, networkToCaip19, networkToCaip2 } from './caip';
 
@@ -169,4 +179,22 @@ export function mapToTransaction(
   }
 
   return transaction;
+}
+
+/**
+ * Maps a Bitcoin Account to a Keyring Account.
+ *
+ * @param account - The Bitcoin account.
+ * @param groupIndex - The group index.
+ * @returns The Keyring account.
+ */
+export function mapToDiscoveredAccount(
+  account: BitcoinAccount,
+  groupIndex: number,
+): DiscoveredAccount {
+  return {
+    type: DiscoveredAccountType.Bip44,
+    scopes: [networkToCaip2[account.network]],
+    derivationPath: `m/${addressTypeToPurpose[account.addressType]}'/${networkToCoinType[account.network]}'/${groupIndex}'`,
+  };
 }

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -59,7 +59,7 @@ const sendFlowUseCases = new SendFlowUseCases(
 const assetsUseCases = new AssetsUseCases(logger, assetRatesClient);
 
 // Application layer
-const keyringHandler = new KeyringHandler(accountsUseCases);
+const keyringHandler = new KeyringHandler(accountsUseCases, snapClient);
 const cronHandler = new CronHandler(logger, accountsUseCases, sendFlowUseCases);
 const rpcHandler = new RpcHandler(sendFlowUseCases, accountsUseCases);
 const userInputHandler = new UserInputHandler(sendFlowUseCases);

--- a/packages/snap/src/infra/ConsoleLoggerAdapter.ts
+++ b/packages/snap/src/infra/ConsoleLoggerAdapter.ts
@@ -2,12 +2,12 @@ import type { Logger } from '../entities';
 import { LogLevel } from '../entities';
 
 const logLevelPriority = {
-  [LogLevel.ERROR]: 0,
-  [LogLevel.WARN]: 1,
-  [LogLevel.INFO]: 2,
-  [LogLevel.DEBUG]: 3,
-  [LogLevel.TRACE]: 4,
-  [LogLevel.SILENT]: 5,
+  [LogLevel.SILENT]: 0,
+  [LogLevel.ERROR]: 1,
+  [LogLevel.WARN]: 2,
+  [LogLevel.INFO]: 3,
+  [LogLevel.DEBUG]: 4,
+  [LogLevel.TRACE]: 5,
 };
 
 export class ConsoleLoggerAdapter implements Logger {

--- a/packages/snap/src/infra/EsploraClientAdapter.ts
+++ b/packages/snap/src/infra/EsploraClientAdapter.ts
@@ -36,6 +36,7 @@ export class EsploraClientAdapter implements BlockchainClient {
       this.#config.stopGap,
       this.#config.parallelRequests,
     );
+
     account.applyUpdate(update);
   }
 

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -185,7 +185,6 @@ describe('AccountUseCases', () => {
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
       expect(mockRepository.insert).not.toHaveBeenCalled();
-      expect(mockSnapClient.emitAccountCreatedEvent).toHaveBeenCalled();
 
       expect(result).toBe(mockExistingAccount);
     });
@@ -202,7 +201,6 @@ describe('AccountUseCases', () => {
 
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
       expect(mockRepository.insert).toHaveBeenCalled();
-      expect(mockSnapClient.emitAccountCreatedEvent).toHaveBeenCalled();
 
       expect(result).toBe(mockAccount);
     });
@@ -232,20 +230,6 @@ describe('AccountUseCases', () => {
       expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
       expect(mockRepository.insert).toHaveBeenCalled();
       expect(mockSnapClient.emitAccountCreatedEvent).not.toHaveBeenCalled();
-    });
-
-    it('propagates an error if emitAccountCreatedEvent throws', async () => {
-      const error = new Error();
-      mockRepository.getByDerivationPath.mockResolvedValue(null);
-      mockSnapClient.emitAccountCreatedEvent.mockRejectedValue(error);
-
-      await expect(
-        useCases.create({ network, entropySource, index, addressType }),
-      ).rejects.toBe(error);
-
-      expect(mockRepository.getByDerivationPath).toHaveBeenCalled();
-      expect(mockRepository.insert).toHaveBeenCalled();
-      expect(mockSnapClient.emitAccountCreatedEvent).toHaveBeenCalled();
     });
   });
 

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -102,7 +102,6 @@ describe('AccountUseCases', () => {
     const addressType: AddressType = 'p2wpkh';
     const entropySource = 'some-source';
     const index = 1;
-    const correlationId = 'some-correlation-id';
 
     const mockAccount = mock<BitcoinAccount>();
 
@@ -126,7 +125,6 @@ describe('AccountUseCases', () => {
           entropySource,
           index,
           addressType: tAddressType,
-          correlationId,
         });
 
         expect(mockRepository.getByDerivationPath).toHaveBeenCalledWith(
@@ -136,10 +134,6 @@ describe('AccountUseCases', () => {
           derivationPath,
           network,
           tAddressType,
-        );
-        expect(mockSnapClient.emitAccountCreatedEvent).toHaveBeenCalledWith(
-          mockAccount,
-          correlationId,
         );
       },
     );
@@ -165,7 +159,6 @@ describe('AccountUseCases', () => {
           entropySource,
           index,
           addressType,
-          correlationId,
         });
 
         expect(mockRepository.getByDerivationPath).toHaveBeenCalledWith(
@@ -175,10 +168,6 @@ describe('AccountUseCases', () => {
           expectedDerivationPath,
           tNetwork,
           addressType,
-        );
-        expect(mockSnapClient.emitAccountCreatedEvent).toHaveBeenCalledWith(
-          mockAccount,
-          correlationId,
         );
       },
     );

--- a/packages/snap/src/use-cases/AccountUseCases.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.ts
@@ -25,6 +25,7 @@ export type CreateAccountParams = {
   entropySource?: string;
   addressType?: AddressType;
   correlationId?: string;
+  synchronize?: boolean;
 };
 
 export class AccountUseCases {
@@ -85,6 +86,7 @@ export class AccountUseCases {
       network,
       correlationId,
       entropySource = 'm',
+      synchronize = false,
     } = req;
 
     const derivationPath = [
@@ -109,6 +111,10 @@ export class AccountUseCases {
     );
 
     await this.#snapClient.emitAccountCreatedEvent(newAccount, correlationId);
+
+    if (synchronize) {
+      await this.fullScan(newAccount);
+    }
 
     this.#logger.info(
       'Bitcoin account created successfully: %s. derivationPath: %s',

--- a/packages/snap/src/use-cases/AccountUseCases.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.ts
@@ -26,13 +26,6 @@ export type CreateAccountParams = {
   addressType?: AddressType;
 };
 
-export type DiscoverAccountParams = {
-  network: Network;
-  index?: number;
-  entropySource?: string;
-  addressType?: AddressType;
-};
-
 export class AccountUseCases {
   readonly #logger: Logger;
 

--- a/packages/snap/src/use-cases/AccountUseCases.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.ts
@@ -24,8 +24,13 @@ export type CreateAccountParams = {
   index?: number;
   entropySource?: string;
   addressType?: AddressType;
-  correlationId?: string;
-  synchronize?: boolean;
+};
+
+export type DiscoverAccountParams = {
+  network: Network;
+  index?: number;
+  entropySource?: string;
+  addressType?: AddressType;
 };
 
 export class AccountUseCases {
@@ -84,9 +89,7 @@ export class AccountUseCases {
       addressType = this.#accountConfig.defaultAddressType,
       index = 0,
       network,
-      correlationId,
       entropySource = 'm',
-      synchronize = false,
     } = req;
 
     const derivationPath = [
@@ -100,7 +103,6 @@ export class AccountUseCases {
     const account = await this.#repository.getByDerivationPath(derivationPath);
     if (account) {
       this.#logger.debug('Account already exists: %s,', account.id);
-      await this.#snapClient.emitAccountCreatedEvent(account, correlationId);
       return account;
     }
 
@@ -109,12 +111,6 @@ export class AccountUseCases {
       network,
       addressType,
     );
-
-    await this.#snapClient.emitAccountCreatedEvent(newAccount, correlationId);
-
-    if (synchronize) {
-      await this.fullScan(newAccount);
-    }
 
     this.#logger.info(
       'Bitcoin account created successfully: %s. derivationPath: %s',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2714,7 +2714,7 @@ __metadata:
   resolution: "@metamask/bitcoin-wallet-snap@workspace:packages/snap"
   dependencies:
     "@jest/globals": "npm:^29.7.0"
-    "@metamask/bitcoindevkit": "npm:^0.1.8"
+    "@metamask/bitcoindevkit": ../../../bdk-wasm/pkg
     "@metamask/key-tree": "npm:^10.1.1"
     "@metamask/keyring-api": "npm:^17.5.0"
     "@metamask/keyring-snap-sdk": "npm:^3.2.0"
@@ -2759,10 +2759,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/bitcoindevkit@npm:^0.1.8":
+"@metamask/bitcoindevkit@file:../../../bdk-wasm/pkg::locator=%40metamask%2Fbitcoin-wallet-snap%40workspace%3Apackages%2Fsnap":
   version: 0.1.8
-  resolution: "@metamask/bitcoindevkit@npm:0.1.8"
-  checksum: 10/10137d0e71159102de8ed1fadd0d5a45960fada8369cd942f0d8d41fdb3e9d91390758b52b3c86879dd6427522d72dcc92d6c70034ba176977b8c0e2df1c59bb
+  resolution: "@metamask/bitcoindevkit@file:../../../bdk-wasm/pkg#../../../bdk-wasm/pkg::hash=8493dd&locator=%40metamask%2Fbitcoin-wallet-snap%40workspace%3Apackages%2Fsnap"
+  checksum: 10/a8321d082488de0b198a8f9a0126fd39e70512eb0d754c28b717a2a903fbc43f6683ab024b26e8f48767170877cf36bfb77b7db54d700435e6114e88af9acf3a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2714,7 +2714,7 @@ __metadata:
   resolution: "@metamask/bitcoin-wallet-snap@workspace:packages/snap"
   dependencies:
     "@jest/globals": "npm:^29.7.0"
-    "@metamask/bitcoindevkit": ../../../bdk-wasm/pkg
+    "@metamask/bitcoindevkit": "npm:^0.1.9"
     "@metamask/key-tree": "npm:^10.1.1"
     "@metamask/keyring-api": "npm:^17.5.0"
     "@metamask/keyring-snap-sdk": "npm:^3.2.0"
@@ -2759,10 +2759,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/bitcoindevkit@file:../../../bdk-wasm/pkg::locator=%40metamask%2Fbitcoin-wallet-snap%40workspace%3Apackages%2Fsnap":
-  version: 0.1.8
-  resolution: "@metamask/bitcoindevkit@file:../../../bdk-wasm/pkg#../../../bdk-wasm/pkg::hash=8493dd&locator=%40metamask%2Fbitcoin-wallet-snap%40workspace%3Apackages%2Fsnap"
-  checksum: 10/a8321d082488de0b198a8f9a0126fd39e70512eb0d754c28b717a2a903fbc43f6683ab024b26e8f48767170877cf36bfb77b7db54d700435e6114e88af9acf3a
+"@metamask/bitcoindevkit@npm:^0.1.9":
+  version: 0.1.9
+  resolution: "@metamask/bitcoindevkit@npm:0.1.9"
+  checksum: 10/7a48ad97395c9b327b55dec6c8e5e127c4bc270c0e5a6465bda11ad700c8d7283bd59b40a1d814cf4dc560274835bc00290d1b52fab4d218f0a3c22a9794564a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Discovering accounts is essentially the same process as batch creation without firing events:
- Extract the address type (purpose) from the derivation path for account creation to be idempotent after accounts have been discovered.
- Move events firing from `createAccount` use case to the handler.
- Fix small issue on `silent` logging being smaller than `trace` instead of higher than `error`.