### PR TITLE
fix: account name passthrough

### DIFF
--- a/packages/snap/integration-test/keyring.test.ts
+++ b/packages/snap/integration-test/keyring.test.ts
@@ -58,9 +58,8 @@ describe('Keyring', () => {
       method: 'keyring_createAccount',
       params: {
         options: {
-          addressType: BtcAccountType.P2wpkh,
+          derivationPath: "m/84'/1'/0'",
           scope: BtcScope.Regtest,
-          index: 0,
           synchronize: true,
         },
       },

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Manage Bitcoin using MetaMask",
   "proposedName": "Bitcoin",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "GuDKvdGqDLqnllsXbghkxnU3h4+Q3hZ/rCYbH5EJQNA=",
+    "shasum": "aimXV44Jeh+xMV4K73E1JRmVDnUPITr+YtE38Xa97zI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/entities/snap.ts
+++ b/packages/snap/src/entities/snap.ts
@@ -77,6 +77,7 @@ export type SnapClient = {
   emitAccountCreatedEvent(
     account: BitcoinAccount,
     correlationId?: string,
+    accountName?: string,
   ): Promise<void>;
 
   /**

--- a/packages/snap/src/handlers/KeyringHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringHandler.test.ts
@@ -82,6 +82,7 @@ describe('KeyringHandler', () => {
         metamask: {
           correlationId,
         },
+        accountNameSuggestion: 'My account',
       };
       const expectedCreateParams: CreateAccountParams = {
         network: scopeToNetwork[BtcScope.Signet],
@@ -90,6 +91,7 @@ describe('KeyringHandler', () => {
         addressType: 'p2pkh',
         synchronize: false,
         correlationId,
+        accountName: 'My account',
       };
 
       await handler.createAccount(options);

--- a/packages/snap/src/handlers/KeyringHandler.ts
+++ b/packages/snap/src/handlers/KeyringHandler.ts
@@ -102,6 +102,7 @@ export class KeyringHandler implements Keyring {
       derivationPath,
       addressType,
       synchronize = false,
+      accountNameSuggestion,
     } = options;
 
     const resolvedIndex = derivationPath
@@ -122,6 +123,7 @@ export class KeyringHandler implements Keyring {
       addressType: resolvedAddressType ?? this.#defaultAddressType,
       correlationId: metamask?.correlationId,
       synchronize,
+      accountName: accountNameSuggestion,
     });
 
     return mapToKeyringAccount(account);

--- a/packages/snap/src/handlers/mappings.ts
+++ b/packages/snap/src/handlers/mappings.ts
@@ -1,6 +1,5 @@
 import { Address } from '@metamask/bitcoindevkit';
 import type {
-  AddressType,
   Amount,
   Network,
   TxOut,

--- a/packages/snap/src/handlers/mappings.ts
+++ b/packages/snap/src/handlers/mappings.ts
@@ -44,22 +44,6 @@ type TransactionEvent = {
   timestamp: number | null;
 };
 
-export const addressTypeToName: Record<AddressType, string> = {
-  p2pkh: 'Legacy',
-  p2sh: 'Nested SegWit',
-  p2wpkh: 'Native SegWit',
-  p2tr: 'Taproot',
-  p2wsh: 'Multisig',
-};
-
-export const networkToName: Record<Network, string> = {
-  bitcoin: 'Bitcoin',
-  testnet: 'Bitcoin Testnet',
-  testnet4: 'Bitcoin Testnet4',
-  signet: 'Bitcoin Signet',
-  regtest: 'Bitcoin Regtest',
-};
-
 /**
  * Maps a Bitcoin Account to a Keyring Account.
  *

--- a/packages/snap/src/infra/SnapClientAdapter.ts
+++ b/packages/snap/src/infra/SnapClientAdapter.ts
@@ -14,12 +14,7 @@ import type {
 import type { BitcoinAccount, SnapClient } from '../entities';
 import { networkToCurrencyUnit } from '../entities';
 import { networkToCaip19 } from '../handlers';
-import {
-  mapToKeyringAccount,
-  mapToTransaction,
-  addressTypeToName,
-  networkToName,
-} from '../handlers/mappings';
+import { mapToKeyringAccount, mapToTransaction } from '../handlers/mappings';
 
 export class SnapClientAdapter implements SnapClient {
   readonly #encrypt: boolean;
@@ -75,12 +70,11 @@ export class SnapClientAdapter implements SnapClient {
   async emitAccountCreatedEvent(
     account: BitcoinAccount,
     correlationId?: string,
+    accountName?: string,
   ): Promise<void> {
     return emitSnapKeyringEvent(snap, KeyringEvent.AccountCreated, {
       account: mapToKeyringAccount(account),
-      accountNameSuggestion: `${networkToName[account.network]} ${
-        addressTypeToName[account.addressType]
-      }`,
+      accountNameSuggestion: accountName,
       displayConfirmation: false,
       displayAccountNameSuggestion: false,
       ...(correlationId ? { metamask: { correlationId } } : {}),

--- a/packages/snap/src/store/BdkAccountRepository.test.ts
+++ b/packages/snap/src/store/BdkAccountRepository.test.ts
@@ -120,8 +120,8 @@ describe('BdkAccountRepository', () => {
       const id1 = 'some-id-1';
       const id2 = 'some-id-2';
       const state = {
-        id1: { ...mockAccountState, id: id1 },
-        id2: { ...mockAccountState, id: id2 },
+        [id1]: { ...mockAccountState, id: id1 },
+        [id2]: { ...mockAccountState, id: id2 },
       };
       const mockAccount1 = { ...mockAccount, id: id1 };
       const mockAccount2 = { ...mockAccount, id: id2 };
@@ -285,15 +285,25 @@ describe('BdkAccountRepository', () => {
     });
 
     it('removes wallet data from store', async () => {
-      mockSnapClient.getState.mockResolvedValue(mockAccountState);
+      const id1 = 'some-id-1';
+      const id2 = 'some-id-2';
+      const mockState = {
+        [id1]: { ...mockAccountState, id: id1 },
+        [id2]: { ...mockAccountState, id: id2 },
+      };
+      const expectedState = {
+        [id2]: { ...mockAccountState, id: id2 },
+      };
 
-      await repo.delete('some-id');
+      mockSnapClient.getState.mockResolvedValue(mockState);
 
-      expect(mockSnapClient.removeState).toHaveBeenNthCalledWith(
-        1,
-        'accounts.some-id',
+      await repo.delete('some-id-1');
+
+      expect(mockSnapClient.setState).toHaveBeenCalledWith(
+        'accounts',
+        expectedState,
       );
-      expect(mockSnapClient.removeState).toHaveBeenLastCalledWith(
+      expect(mockSnapClient.removeState).toHaveBeenCalledWith(
         "derivationPaths.m/84'/0'/0'",
       );
     });

--- a/packages/snap/src/store/BdkAccountRepository.ts
+++ b/packages/snap/src/store/BdkAccountRepository.ts
@@ -193,7 +193,8 @@ export class BdkAccountRepository implements BitcoinAccountRepository {
     const accounts = (await this.#snapClient.getState('accounts')) as
       | SnapState['accounts']
       | null;
-    if (!accounts || !accounts[id]) {
+    if (!accounts?.[id]) {
+      console.log(accounts);
       return;
     }
 

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -104,6 +104,7 @@ describe('AccountUseCases', () => {
       addressType: 'p2wpkh',
       synchronize: false,
       correlationId: 'correlation-id',
+      accountName: 'My account',
     };
     const mockAccount = mock<BitcoinAccount>({ network: createParams.network });
 
@@ -145,6 +146,7 @@ describe('AccountUseCases', () => {
         expect(mockSnapClient.emitAccountCreatedEvent).toHaveBeenCalledWith(
           mockAccount,
           createParams.correlationId,
+          createParams.accountName,
         );
         expect(mockChain.fullScan).toHaveBeenCalledWith(mockAccount);
       },
@@ -184,6 +186,7 @@ describe('AccountUseCases', () => {
         expect(mockSnapClient.emitAccountCreatedEvent).toHaveBeenCalledWith(
           mockAccount,
           createParams.correlationId,
+          createParams.accountName,
         );
         expect(mockChain.fullScan).toHaveBeenCalledWith(mockAccount);
       },


### PR DESCRIPTION
- Pass through account name
- Fix bug in `delete` account where the account is set to null but the key is not removed.