### PR TITLE
feat: 429 retry mechanism

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "RQHdHEnbYoclZgGjvNdaFXlrMnPrkKMXwZ2nuMYPPU0=",
+    "shasum": "NuAflTRE9TaXDZVtDUqnFrPckm8g1eVCX7KSgtuMJE8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/entities/snap.ts
+++ b/packages/snap/src/entities/snap.ts
@@ -17,7 +17,7 @@ export type SnapState = {
 };
 
 export type AccountState = {
-  // Split derivation path.
+  // Derivation path.
   derivationPath: string[];
   // Wallet data.
   wallet: string;

--- a/packages/snap/src/infra/EsploraClientAdapter.ts
+++ b/packages/snap/src/infra/EsploraClientAdapter.ts
@@ -17,7 +17,11 @@ export class EsploraClientAdapter implements BlockchainClient {
 
   readonly #config: ChainConfig;
 
+  private static fetchPatched = false;
+
   constructor(config: ChainConfig) {
+    EsploraClientAdapter.patchFetch();
+
     this.#clients = {
       bitcoin: new EsploraClient(config.url.bitcoin),
       testnet: new EsploraClient(config.url.testnet),
@@ -36,7 +40,6 @@ export class EsploraClientAdapter implements BlockchainClient {
       this.#config.stopGap,
       this.#config.parallelRequests,
     );
-
     account.applyUpdate(update);
   }
 
@@ -55,5 +58,39 @@ export class EsploraClientAdapter implements BlockchainClient {
 
   async getFeeEstimates(network: Network): Promise<FeeEstimates> {
     return this.#clients[network].get_fee_estimates();
+  }
+
+  /**
+   * Monkey‑patch `fetch` so every request automatically retries on HTTP 429
+   * using exponential back‑off (baseDelay ms × 2^attempt, up to maxRetries).
+   * This applies to BDK calls because they delegate to `fetch` in WASM builds.
+   *
+   * NOTE: For idempotent GETs this is safe; for POSTs BDK currently performs
+   * only transaction broadcast (safe to retry).
+   */
+  private static patchFetch(maxRetries = 3, baseDelay = 500): void {
+    if (this.fetchPatched) return;
+
+    const originalFetch = globalThis.fetch.bind(globalThis);
+
+    globalThis.fetch = async (
+      ...args: Parameters<typeof fetch>
+    ): Promise<Response> => {
+      for (let attempt = 0; ; attempt++) {
+        const res = await originalFetch(...args);
+        if (res.status !== 429 || attempt >= maxRetries) {
+          return res;
+        }
+
+        console.log('inside 429 retry', args);
+
+        // Exponential back‑off: 0.5s, 1s, 2s, ...
+        await new Promise((r) => setTimeout(r, baseDelay * 2 ** attempt));
+        // For requests with a consumed body you'd need to recreate the Request.
+        // BDK's Esplora calls are GET/POST without streaming bodies, so safe.
+      }
+    };
+
+    this.fetchPatched = true;
   }
 }


### PR DESCRIPTION
Retry on 429 by monkey patching the `fetch` so that it is used internally by BDK (WASM).