### PR TITLE
fix: entropy source in options

### DIFF
--- a/packages/snap/integration-test/keyring.test.ts
+++ b/packages/snap/integration-test/keyring.test.ts
@@ -69,7 +69,9 @@ describe('Keyring', () => {
       type: BtcAccountType.P2wpkh,
       id: expect.anything(),
       address: TEST_ADDRESS_REGTEST,
-      options: {},
+      options: {
+        entropySource: 'm',
+      },
       scopes: [BtcScope.Regtest],
       methods: [BtcMethod.SendBitcoin],
     });
@@ -144,7 +146,9 @@ describe('Keyring', () => {
       type: requestOpts.addressType,
       id: expect.anything(),
       address: expectedAddress,
-      options: {},
+      options: {
+        entropySource: 'm',
+      },
       scopes: [requestOpts.scope],
       methods: [BtcMethod.SendBitcoin],
     });

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "RQHdHEnbYoclZgGjvNdaFXlrMnPrkKMXwZ2nuMYPPU0=",
+    "shasum": "a4uu803ic5YoTP3LLoFSgwmrEtC8kjh/ovXBdhQuGCY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/handlers/KeyringHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringHandler.test.ts
@@ -54,6 +54,7 @@ describe('KeyringHandler', () => {
     addressType: 'p2wpkh',
     balance: { trusted_spendable: { to_btc: () => 1 } },
     network: 'bitcoin',
+    derivationPath: ['myEntropy', "84'", "0'", "0'"],
   });
   const defaultAddressType: AddressType = 'p2wpkh';
 
@@ -303,7 +304,9 @@ describe('KeyringHandler', () => {
         type: BtcAccountType.P2wpkh,
         scopes: [BtcScope.Mainnet],
         address: 'bc1qaddress...',
-        options: {},
+        options: {
+          entropySource: 'myEntropy',
+        },
         methods: [BtcMethod.SendBitcoin],
       };
 
@@ -330,7 +333,9 @@ describe('KeyringHandler', () => {
           type: BtcAccountType.P2wpkh,
           scopes: [BtcScope.Mainnet],
           address: 'bc1qaddress...',
-          options: {},
+          options: {
+            entropySource: 'myEntropy',
+          },
           methods: [BtcMethod.SendBitcoin],
         },
       ];

--- a/packages/snap/src/handlers/mappings.ts
+++ b/packages/snap/src/handlers/mappings.ts
@@ -55,7 +55,9 @@ export function mapToKeyringAccount(account: BitcoinAccount): KeyringAccount {
     scopes: [networkToScope[account.network]],
     id: account.id,
     address: account.peekAddress(0).address.toString(),
-    options: {},
+    options: {
+      entropySource: account.derivationPath[0] ?? null,
+    },
     methods: [BtcMethod.SendBitcoin],
   };
 }


### PR DESCRIPTION
Return the entropy source as part of the KeyringAccount `options` as MM does not assign the entropy source automatically when passed to the Snap.