### PR TITLE
feat: retry mechanism

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "@metamask/keyring-api": "^17.6.0",
+    "@metamask/keyring-api": "^18.0.0",
     "@metamask/providers": "^22.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -1,3 +1,10 @@
+// First operation is monkey patching `fetch`. This is a temporary solution improving
+// rate limit errors. To be removed before prod release.
+/* eslint-disable import-x/first,import-x/order */
+import { patchFetchNetworkErrors } from './infra/fetch';
+
+patchFetchNetworkErrors();
+
 import type {
   OnAssetsConversionHandler,
   OnAssetsLookupHandler,
@@ -25,6 +32,8 @@ import {
 } from './infra';
 import { BdkAccountRepository, JSXSendFlowRepository } from './store';
 import { AccountUseCases, AssetsUseCases, SendFlowUseCases } from './use-cases';
+
+/* eslint-enable import-x/first,import-x/order */
 
 // Infra layer
 const logger = new ConsoleLoggerAdapter(Config.logLevel);

--- a/packages/snap/src/infra/fetch.ts
+++ b/packages/snap/src/infra/fetch.ts
@@ -1,0 +1,40 @@
+/* eslint-disable no-restricted-globals */
+
+/**
+ * Monkey patch for globalThis `fetch` introducing a retry mechanism on network error.
+ *
+ * @param maxRetries Max number of retries before failure.
+ * @param baseDelay Base delay in ms for exponential decay.
+ */
+export function patchFetchNetworkErrors(maxRetries = 3, baseDelay = 500): void {
+  if ((globalThis as any).__fetchPatched) {
+    return;
+  }
+
+  const original = globalThis.fetch.bind(globalThis);
+
+  globalThis.fetch = async (
+    input: URL | RequestInfo,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        const res = await original(input, init);
+
+        if (res.status !== 429 || attempt >= maxRetries) {
+          return res;
+        }
+      } catch (error) {
+        if (!(error instanceof TypeError) || attempt >= maxRetries) {
+          throw error;
+        }
+      }
+
+      // Exponential back‑off
+      const delay = baseDelay * 2 ** attempt * (0.75 + Math.random() * 0.5);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  };
+
+  (globalThis as any).__fetchPatched = true;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,7 +2735,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/bitcoin-wallet-test-dapp@workspace:packages/site"
   dependencies:
-    "@metamask/keyring-api": "npm:^17.6.0"
+    "@metamask/keyring-api": "npm:^18.0.0"
     "@metamask/providers": "npm:^22.1.0"
     "@svgr/webpack": "npm:^8.1.0"
     "@testing-library/dom": "npm:^8.17.1"
@@ -2997,18 +2997,6 @@ __metadata:
     "@noble/hashes": "npm:^1.3.2"
     "@scure/base": "npm:^1.0.0"
   checksum: 10/29b2db7f2626414f6147e6a25aae16b1a012485aa394fb6ad2b3f26519455dae7e6e6fdd502f279e1924251b7058a853982297f37761372ed034db5f150fc720
-  languageName: node
-  linkType: hard
-
-"@metamask/keyring-api@npm:^17.6.0":
-  version: 17.6.0
-  resolution: "@metamask/keyring-api@npm:17.6.0"
-  dependencies:
-    "@metamask/keyring-utils": "npm:^3.0.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.1.0"
-    bitcoin-address-validation: "npm:^2.2.3"
-  checksum: 10/96d847176e6de4a24f62dce4f69e4756842bba50dd7cb90aa1a37626fb0ac9db68187d011d1ba19a71ca7396fa2c0aee27628dec773b6af20c99628c9e85ffe4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Temporary improvement by monkey patching `fetch` with a retry mechanism to avoid getting rate limited (429) while performing parallel API calls. Particularly useful for initial account discovery.

Should be removed for production when rate limit is not an issue anymore.