### PR TITLE
feat: Market data

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "4Za/36SDZ7XDTNzuHPetofhUQvcAzW0xplsDRtF0VJA=",
+    "shasum": "p+sQZuFeJ9QT0f7dhbP7KBwpqbbyIIKPHitPyjqyOiw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/entities/rates.ts
+++ b/packages/snap/src/entities/rates.ts
@@ -1,22 +1,23 @@
-import type { HistoricalPriceValue } from '@metamask/snaps-sdk';
+import type { HistoricalPriceValue, MarketData } from '@metamask/snaps-sdk';
 import type { CaipAssetType } from '@metamask/utils';
 
 export type TimePeriod = 'P1D' | 'P7D' | 'P1M' | 'P3M' | 'P1Y' | 'P1000Y';
-export type AssetRate = [CaipAssetType, number | null];
 
-export type ExchangeRates = {
-  [ticker: string]: {
-    value: number;
-  };
+export type AssetRate = [CaipAssetType, SpotPrice | null];
+
+export type SpotPrice = {
+  price: number;
+  marketData?: MarketData;
 };
 
 export type AssetRatesClient = {
   /**
-   * Returns a list of exchange rates for all supported currencies.
+   * Returns the spot price of an asset relative to an other including market data.
    *
-   * @param baseCurrency - the currency to convert prices to. Defaults to 'btc'.
+   * @param vsCurrency - the currency to convert prices to. Defaults to 'usd'.
+   * @param baseCurrency - the currency to get prices for. Defaults to 'bitcoin'.
    */
-  exchangeRates(baseCurrency?: string): Promise<ExchangeRates>;
+  spotPrices(vsCurrency?: string, baseCurrency?: string): Promise<SpotPrice>;
 
   /**
    * Returns a list of historical prices for a token against another.

--- a/packages/snap/src/handlers/AssetsHandler.ts
+++ b/packages/snap/src/handlers/AssetsHandler.ts
@@ -87,6 +87,7 @@ export class AssetsHandler {
 
   async conversion(
     conversions: OnAssetsConversionArguments['conversions'],
+    includeMarketData?: boolean,
   ): Promise<OnAssetsConversionResponse> {
     const conversionTime = getCurrentUnixTimestamp();
 
@@ -111,7 +112,8 @@ export class AssetsHandler {
           )) {
             conversionRates[fromKey][toAsset] = rate
               ? {
-                  rate: rate.toString(),
+                  rate: rate.price.toString(),
+                  marketData: includeMarketData ? rate.marketData : undefined,
                   conversionTime,
                   expirationTime: conversionTime + this.#expirationInterval,
                 }

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -89,7 +89,8 @@ export const onAssetsLookup: OnAssetsLookupHandler = async () =>
 
 export const onAssetsConversion: OnAssetsConversionHandler = async ({
   conversions,
-}) => assetsHandler.conversion(conversions);
+  includeMarketData,
+}) => assetsHandler.conversion(conversions, includeMarketData);
 
 export const onAssetHistoricalPrice: OnAssetHistoricalPriceHandler = async ({
   from,

--- a/packages/snap/src/use-cases/SendFlowUseCases.test.ts
+++ b/packages/snap/src/use-cases/SendFlowUseCases.test.ts
@@ -641,14 +641,14 @@ describe('SendFlowUseCases', () => {
       locale: 'en',
     };
     const mockExchangeRates = {
-      usd: { value: 200000 },
+      price: 200000,
     };
     const mockFeeRate = 4.4;
 
     beforeEach(() => {
       mockSendFlowRepository.getContext.mockResolvedValue(mockContext);
       mockChain.getFeeEstimates.mockResolvedValue(mockFeeEstimates);
-      mockRatesClient.exchangeRates.mockResolvedValue(mockExchangeRates);
+      mockRatesClient.spotPrices.mockResolvedValue(mockExchangeRates);
       mockSnapClient.scheduleBackgroundEvent.mockResolvedValue('event-id');
       mockSnapClient.getPreferences.mockResolvedValue(mockPreferences);
     });
@@ -687,7 +687,7 @@ describe('SendFlowUseCases', () => {
           ...mockContext,
           backgroundEventId: 'event-id',
           exchangeRate: {
-            conversionRate: mockExchangeRates.usd.value,
+            conversionRate: mockExchangeRates.price,
             conversionDate: expect.any(Number),
             currency: 'USD',
           },
@@ -723,6 +723,8 @@ describe('SendFlowUseCases', () => {
         ...mockPreferences,
         currency: 'unknown',
       });
+      const error = new Error('spotPrices failed');
+      mockRatesClient.spotPrices.mockRejectedValue(error);
 
       await useCases.refresh('interface-id');
 

--- a/packages/snap/src/use-cases/SendFlowUseCases.ts
+++ b/packages/snap/src/use-cases/SendFlowUseCases.ts
@@ -352,15 +352,12 @@ export class SendFlowUseCases {
 
       // Exchange rate is only relevant for Bitcoin
       if (network === 'bitcoin') {
-        const exchangeRates = await this.#ratesClient.exchangeRates();
-        const conversionRate = exchangeRates[currency];
-        if (conversionRate) {
-          updatedContext.exchangeRate = {
-            conversionRate: conversionRate.value,
-            conversionDate: getCurrentUnixTimestamp(),
-            currency: currency.toUpperCase(),
-          };
-        }
+        const spotPrice = await this.#ratesClient.spotPrices(currency);
+        updatedContext.exchangeRate = {
+          conversionRate: spotPrice.price,
+          conversionDate: getCurrentUnixTimestamp(),
+          currency: currency.toUpperCase(),
+        };
       }
 
       updatedContext = await this.#computeFee(updatedContext);


### PR DESCRIPTION
Return market data `onAssetConversion`.

Fixes a bug where some values can be `null` for historical prices.

![Screenshot 2025-06-12 at 15 08 36](https://github.com/user-attachments/assets/8ebb1ab3-e158-42d3-8626-b42673669a57)
