### PR TITLE
fix: synchronize empty accounts

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "e000UALMbvCh4/m50TO2Pzkn7IdmVrPMZLoKiXEoBlo=",
+    "shasum": "blxZsyMRbJqlWj/h6lNPc0gUFaEpEXrLXy0vz5/jZQM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "blxZsyMRbJqlWj/h6lNPc0gUFaEpEXrLXy0vz5/jZQM=",
+    "shasum": "IUZJm6RtHYnM5l2i0mUVBK7HBIWIJ8h56Tml9ZB6E4o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/config.ts
+++ b/packages/snap/src/config.ts
@@ -9,7 +9,7 @@ export const Config: SnapConfig = {
   encrypt: false,
   chain: {
     parallelRequests: 1,
-    stopGap: 5,
+    stopGap: 2,
     url: {
       bitcoin: process.env.ESPLORA_BITCOIN ?? 'https://blockstream.info/api',
       testnet:

--- a/packages/snap/src/entities/account.ts
+++ b/packages/snap/src/entities/account.ts
@@ -13,6 +13,7 @@ import type {
   WalletTx,
   Amount,
   ScriptBuf,
+  Address,
 } from '@metamask/bitcoindevkit';
 
 import type { Inscription } from './meta-protocols';
@@ -56,6 +57,11 @@ export type BitcoinAccount = {
    * The network in which the account operates.
    */
   network: Network;
+
+  /**
+   * The public address representing this account. Usually address at index 0.
+   */
+  publicAddress: Address;
 
   /**
    * Get an address at a given index.

--- a/packages/snap/src/handlers/KeyringHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringHandler.test.ts
@@ -1,5 +1,4 @@
 import type {
-  AddressInfo,
   Amount,
   Transaction,
   Txid,
@@ -57,6 +56,7 @@ describe('KeyringHandler', () => {
     derivationPath: ['myEntropy', "84'", "0'", "0'"],
     entropySource: 'myEntropy',
     accountIndex: 0,
+    publicAddress: mockAddress,
   });
   const defaultAddressType: AddressType = 'p2wpkh';
 
@@ -64,11 +64,6 @@ describe('KeyringHandler', () => {
 
   beforeEach(() => {
     mockAccounts.create.mockResolvedValue(mockAccount);
-    mockAccount.peekAddress.mockReturnValue(
-      mock<AddressInfo>({
-        address: mockAddress,
-      }),
-    );
   });
 
   describe('createAccount', () => {

--- a/packages/snap/src/handlers/mappings.ts
+++ b/packages/snap/src/handlers/mappings.ts
@@ -54,7 +54,7 @@ export function mapToKeyringAccount(account: BitcoinAccount): KeyringAccount {
     type: addressTypeToCaip[account.addressType] as KeyringAccount['type'],
     scopes: [networkToScope[account.network]],
     id: account.id,
-    address: account.peekAddress(0).address.toString(),
+    address: account.publicAddress.toString(),
     options: {
       entropySource: account.entropySource,
     },

--- a/packages/snap/src/infra/BdkAccountAdapter.ts
+++ b/packages/snap/src/infra/BdkAccountAdapter.ts
@@ -14,6 +14,7 @@ import type {
   WalletTx,
   Amount,
   ScriptBuf,
+  Address,
 } from '@metamask/bitcoindevkit';
 import {
   UnconfirmedTx,
@@ -106,6 +107,10 @@ export class BdkAccountAdapter implements BitcoinAccount {
 
   get network(): Network {
     return this.#wallet.network;
+  }
+
+  get publicAddress(): Address {
+    return this.peekAddress(0).address;
   }
 
   peekAddress(index: number): AddressInfo {

--- a/packages/snap/src/infra/jsx/ReviewTransactionView.tsx
+++ b/packages/snap/src/infra/jsx/ReviewTransactionView.tsx
@@ -24,7 +24,11 @@ import {
 } from './format';
 import { Config } from '../../config';
 import type { Messages, ReviewTransactionContext } from '../../entities';
-import { BlockTime, ReviewTransactionEvent } from '../../entities';
+import {
+  BlockTime,
+  networkToCurrencyUnit,
+  ReviewTransactionEvent,
+} from '../../entities';
 import { networkToScope } from '../../handlers';
 
 type ReviewTransactionViewProps = {
@@ -36,20 +40,14 @@ export const ReviewTransactionView: SnapComponent<
   ReviewTransactionViewProps
 > = ({ context, messages }) => {
   const t = translate(messages);
-  const {
-    amount,
-    currency,
-    exchangeRate,
-    recipient,
-    network,
-    from,
-    explorerUrl,
-  } = context;
+  const { amount, exchangeRate, recipient, network, from, explorerUrl } =
+    context;
 
   const psbt = Psbt.from_string(context.psbt);
   const fee = psbt.fee().to_sat();
   const feeRate = psbt.fee_rate()?.to_sat_per_vb_floor();
   const total = BigInt(amount) + fee;
+  const currency = networkToCurrencyUnit[network];
 
   return (
     <Container>

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -142,6 +142,7 @@ describe('AccountUseCases', () => {
           createParams.network,
           tAddressType,
         );
+        expect(mockAccount.revealNextAddress).toHaveBeenCalled();
         expect(mockRepository.insert).toHaveBeenCalledWith(mockAccount);
         expect(mockSnapClient.emitAccountCreatedEvent).toHaveBeenCalledWith(
           mockAccount,

--- a/packages/snap/src/use-cases/AccountUseCases.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.ts
@@ -150,6 +150,8 @@ export class AccountUseCases {
       addressType,
     );
 
+    newAccount.revealNextAddress();
+
     await this.#repository.insert(newAccount);
 
     // First notify the event has been created, then full scan.
@@ -164,8 +166,9 @@ export class AccountUseCases {
     }
 
     this.#logger.info(
-      'Bitcoin account created successfully: %s. Request: %o',
+      'Bitcoin account created successfully: %s. Public address: %s, Request: %o',
       newAccount.id,
+      newAccount.publicAddress,
       req,
     );
     return newAccount;

--- a/packages/snap/src/use-cases/SendFlowUseCases.test.ts
+++ b/packages/snap/src/use-cases/SendFlowUseCases.test.ts
@@ -1,8 +1,4 @@
-import type {
-  FeeEstimates,
-  Network,
-  AddressInfo,
-} from '@metamask/bitcoindevkit';
+import type { FeeEstimates, Network } from '@metamask/bitcoindevkit';
 import { Psbt, Address, Amount } from '@metamask/bitcoindevkit';
 import type { GetPreferencesResult } from '@metamask/snaps-sdk';
 import { UserRejectedRequestError } from '@metamask/snaps-sdk';
@@ -63,7 +59,7 @@ describe('SendFlowUseCases', () => {
     // TODO: enable when this is merged: https://github.com/rustwasm/wasm-bindgen/issues/1818
     /* eslint-disable @typescript-eslint/naming-convention */
     balance: { trusted_spendable: { to_sat: () => BigInt(1234) } },
-    peekAddress: jest.fn(),
+    publicAddress: mock<Address>({ toString: () => 'myAddress' }),
   });
   const mockPreferences = mock<GetPreferencesResult>({
     currency: 'usd',
@@ -88,11 +84,6 @@ describe('SendFlowUseCases', () => {
   describe('displayForm', () => {
     beforeEach(() => {
       mockAccountRepository.get.mockResolvedValue(mockAccount);
-      mockAccount.peekAddress.mockReturnValue(
-        mock<AddressInfo>({
-          address: mock<Address>({ toString: () => 'myAddress' }),
-        }),
-      );
       mockSendFlowRepository.insertForm.mockResolvedValue('interface-id');
       mockSnapClient.getPreferences.mockResolvedValue(mockPreferences);
     });
@@ -576,11 +567,7 @@ describe('SendFlowUseCases', () => {
 
     it('sets account from state on Account', async () => {
       const accountId = 'myAccount2';
-      mockAccount.peekAddress.mockReturnValue(
-        mock<AddressInfo>({
-          address: mock<Address>({ toString: () => 'myAddress2' }),
-        }),
-      );
+      mockAccount.publicAddress.toString = () => 'myAddress2';
       mockAccountRepository.get.mockResolvedValue({
         ...mockAccount,
         id: accountId,

--- a/packages/snap/src/use-cases/SendFlowUseCases.ts
+++ b/packages/snap/src/use-cases/SendFlowUseCases.ts
@@ -82,7 +82,7 @@ export class SendFlowUseCases {
       currency: networkToCurrencyUnit[account.network],
       account: {
         id: account.id,
-        address: account.peekAddress(0).address.toString(), // FIXME: Address should not be needed in the send flow
+        address: account.publicAddress.toString(), // FIXME: Address should not be needed in the send flow
       },
       network: account.network,
       feeRate: this.#fallbackFeeRate,
@@ -376,7 +376,7 @@ export class SendFlowUseCases {
       balance: account.balance.trusted_spendable.to_sat().toString(),
       account: {
         id: account.id,
-        address: account.peekAddress(0).address.toString(), // FIXME: Address should not be needed in the send flow
+        address: account.publicAddress.toString(), // FIXME: Address should not be needed in the send flow
       },
       errors: {},
       currency: context.currency,


### PR DESCRIPTION
Currently, new accounts with no history fail to synchronize because the first address is not revealed. Also adds some little fixes:
- currency wrongly displayed when fiat is selected
- expose `publicAddress` instead of `peekAddress` to encapsulate the logic on what the public address is.