### PR TITLE
feat: add account options

### DIFF
--- a/packages/snap/integration-test/constants.ts
+++ b/packages/snap/integration-test/constants.ts
@@ -1,4 +1,4 @@
-import { BtcScope } from '@metamask/keyring-api';
+import { BtcAccountType, BtcScope } from '@metamask/keyring-api';
 
 import { CurrencyUnit } from '../src/entities';
 import { Caip19Asset } from '../src/handlers/caip';
@@ -34,4 +34,19 @@ export const FUNDING_TX = {
     },
   ],
   type: 'receive',
+};
+
+export const accountTypeToPurpose: Record<BtcAccountType, string> = {
+  [BtcAccountType.P2pkh]: "44'",
+  [BtcAccountType.P2sh]: "49'",
+  [BtcAccountType.P2wpkh]: "84'",
+  [BtcAccountType.P2tr]: "86'",
+};
+
+export const scopeToCoinType: Record<BtcScope, string> = {
+  [BtcScope.Mainnet]: "0'",
+  [BtcScope.Testnet]: "1'",
+  [BtcScope.Testnet4]: "1'",
+  [BtcScope.Signet]: "1'",
+  [BtcScope.Regtest]: "1'",
 };

--- a/packages/snap/integration-test/keyring.test.ts
+++ b/packages/snap/integration-test/keyring.test.ts
@@ -9,6 +9,8 @@ import {
   ORIGIN,
   TEST_ADDRESS_REGTEST,
   TEST_ADDRESS_MAINNET,
+  scopeToCoinType,
+  accountTypeToPurpose,
 } from './constants';
 import { CurrencyUnit } from '../src/entities';
 import { Caip19Asset } from '../src/handlers/caip';
@@ -72,6 +74,13 @@ describe('Keyring', () => {
       address: TEST_ADDRESS_REGTEST,
       options: {
         entropySource: 'm',
+        entropy: {
+          type: 'mnemonic',
+          id: 'm',
+          groupIndex: 0,
+          derivationPath: "m/84'/1'/0'",
+        },
+        exportable: false,
       },
       scopes: [BtcScope.Regtest],
       methods: [BtcMethod.SendBitcoin],
@@ -149,6 +158,13 @@ describe('Keyring', () => {
       address: expectedAddress,
       options: {
         entropySource: 'm',
+        entropy: {
+          type: 'mnemonic',
+          id: 'm',
+          groupIndex: requestOpts.index,
+          derivationPath: `m/${accountTypeToPurpose[requestOpts.addressType]}/${scopeToCoinType[requestOpts.scope]}/${requestOpts.index}'`,
+        },
+        exportable: false,
       },
       scopes: [requestOpts.scope],
       methods: [BtcMethod.SendBitcoin],

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "HVa+ZDnc20usQMTbRcF0hFKbHJg3+CffZScpQOiW58c=",
+    "shasum": "1JX8CkzNZKtn2kBz/lVEViAX+x8x2XQbzbJkHBRyGo8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/handlers/KeyringHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringHandler.test.ts
@@ -251,9 +251,10 @@ describe('KeyringHandler', () => {
             addressType: caipToAddressType[addrType],
             network: scopeToNetwork[scope],
             listTransactions: jest.fn().mockReturnValue([{}]), // has history
+            derivationPath: ['m', "84'", "0'", "0'"],
           });
 
-          expected.push(mapToDiscoveredAccount(acc, groupIndex));
+          expected.push(mapToDiscoveredAccount(acc));
           mockAccounts.discover.mockResolvedValueOnce(acc);
         });
       });
@@ -352,6 +353,13 @@ describe('KeyringHandler', () => {
         address: 'bc1qaddress...',
         options: {
           entropySource: 'myEntropy',
+          entropy: {
+            derivationPath: "m/84'/0'/0'",
+            groupIndex: 0,
+            id: 'myEntropy',
+            type: 'mnemonic',
+          },
+          exportable: false,
         },
         methods: [BtcMethod.SendBitcoin],
       };
@@ -381,6 +389,13 @@ describe('KeyringHandler', () => {
           address: 'bc1qaddress...',
           options: {
             entropySource: 'myEntropy',
+            entropy: {
+              derivationPath: "m/84'/0'/0'",
+              groupIndex: 0,
+              id: 'myEntropy',
+              type: 'mnemonic',
+            },
+            exportable: false,
           },
           methods: [BtcMethod.SendBitcoin],
         },

--- a/packages/snap/src/handlers/KeyringHandler.ts
+++ b/packages/snap/src/handlers/KeyringHandler.ts
@@ -228,7 +228,7 @@ export class KeyringHandler implements Keyring {
     // Return only accounts with history.
     return accounts
       .filter((account) => account.listTransactions().length > 0)
-      .map((account) => mapToDiscoveredAccount(account, groupIndex));
+      .map(mapToDiscoveredAccount);
   }
 
   async getAccountBalances(

--- a/packages/snap/src/handlers/mappings.ts
+++ b/packages/snap/src/handlers/mappings.ts
@@ -56,7 +56,14 @@ export function mapToKeyringAccount(account: BitcoinAccount): KeyringAccount {
     id: account.id,
     address: account.publicAddress.toString(),
     options: {
-      entropySource: account.entropySource,
+      entropySource: account.entropySource, // TODO: Legacy field. To be removed once multichain accounts are out.
+      exportable: false,
+      entropy: {
+        type: 'mnemonic',
+        id: account.entropySource,
+        derivationPath: `m/${account.derivationPath.slice(1).join('/')}`,
+        groupIndex: account.accountIndex,
+      },
     },
     methods: [BtcMethod.SendBitcoin],
   };
@@ -180,6 +187,6 @@ export function mapToDiscoveredAccount(
   return {
     type: DiscoveredAccountType.Bip44,
     scopes: [networkToScope[account.network]],
-    derivationPath: `m/${addressTypeToPurpose[account.addressType]}'/${networkToCoinType[account.network]}'/${groupIndex}'`,
+    derivationPath: `m/${account.derivationPath.slice(1).join('/')}`,
   };
 }

--- a/packages/snap/src/handlers/mappings.ts
+++ b/packages/snap/src/handlers/mappings.ts
@@ -17,12 +17,7 @@ import {
   DiscoveredAccountType,
 } from '@metamask/keyring-api';
 
-import {
-  addressTypeToPurpose,
-  networkToCoinType,
-  networkToCurrencyUnit,
-  type BitcoinAccount,
-} from '../entities';
+import { networkToCurrencyUnit, type BitcoinAccount } from '../entities';
 import type { Caip19Asset } from './caip';
 import { addressTypeToCaip, networkToCaip19, networkToScope } from './caip';
 
@@ -177,12 +172,10 @@ export function mapToTransaction(
  * Maps a Bitcoin Account to a Discovered Account.
  *
  * @param account - The Bitcoin account.
- * @param groupIndex - The group index.
  * @returns The Discovered account.
  */
 export function mapToDiscoveredAccount(
   account: BitcoinAccount,
-  groupIndex: number,
 ): DiscoveredAccount {
   return {
     type: DiscoveredAccountType.Bip44,


### PR DESCRIPTION
`keyring-api` now adds typed `AccountOptions` that we need to return 