### PR TITLE
feat: utxo management in submitRequest

### DIFF
--- a/packages/snap/integration-test/client-request.test.ts
+++ b/packages/snap/integration-test/client-request.test.ts
@@ -157,7 +157,7 @@ describe('OnClientRequestHandler', () => {
         asset: {
           unit: CurrencyUnit.Regtest,
           type: Caip19Asset.Regtest,
-          amount: '0.00001053',
+          amount: '0.00001393',
           fungible: true,
         },
       },

--- a/packages/snap/integration-test/client-request.test.ts
+++ b/packages/snap/integration-test/client-request.test.ts
@@ -157,7 +157,7 @@ describe('OnClientRequestHandler', () => {
         asset: {
           unit: CurrencyUnit.Regtest,
           type: Caip19Asset.Regtest,
-          amount: '0.00001393',
+          amount: '0.00001053',
           fungible: true,
         },
       },

--- a/packages/snap/integration-test/keyring-request.test.ts
+++ b/packages/snap/integration-test/keyring-request.test.ts
@@ -7,7 +7,6 @@ import { BlockchainTestUtils } from './blockchain-utils';
 import { MNEMONIC, ORIGIN } from './constants';
 import { AccountCapability } from '../src/entities';
 import type { FillPsbtResponse } from '../src/handlers/KeyringRequestHandler';
-import { Utxo } from '../src/handlers/mappings';
 
 const ACCOUNT_INDEX = 3;
 const submitRequestMethod = 'keyring_submitRequest';

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "dQsAaHhtEzROifsEyrizAbLtoxcDNyWTHe8hCnBzd0I=",
+    "shasum": "QedWcB/grGnkSnSmnE3CEJZLrfkpwR5z7HbF8B/HKk4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/entities/account.ts
+++ b/packages/snap/src/entities/account.ts
@@ -64,6 +64,11 @@ export type BitcoinAccount = {
   publicAddress: Address;
 
   /**
+   * The public descriptor of the account.
+   */
+  publicDescriptor: string;
+
+  /**
    * The capabilities of the account.
    */
   capabilities: AccountCapability[];
@@ -143,6 +148,14 @@ export type BitcoinAccount = {
   extractTransaction(psbt: Psbt, maxFeeRate?: number): Transaction;
 
   /**
+   * Get a UTXO by outpoint.
+   *
+   * @param outpoint - Outpoint of the utxo in the format <txid>:<vout>.
+   * @returns the wallet UTXO or undefined if the UTXO is not found
+   */
+  getUtxo(outpoint: string): LocalOutput | undefined;
+
+  /**
    * Get the list of UTXOs
    *
    * @returns the list of UTXOs
@@ -208,6 +221,9 @@ export enum AccountCapability {
   FillPsbt = 'fillPsbt',
   BroadcastPsbt = 'broadcastPsbt',
   SendTransfer = 'sendTransfer',
+  GetUtxo = 'getUtxo',
+  ListUtxos = 'listUtxos',
+  PublicDescriptor = 'publicDescriptor',
 }
 
 /**

--- a/packages/snap/src/infra/BdkAccountAdapter.ts
+++ b/packages/snap/src/infra/BdkAccountAdapter.ts
@@ -22,6 +22,7 @@ import {
   SignOptions,
   Txid,
   Wallet,
+  OutPoint,
 } from '@metamask/bitcoindevkit';
 
 import {
@@ -123,6 +124,10 @@ export class BdkAccountAdapter implements BitcoinAccount {
     return this.peekAddress(0).address;
   }
 
+  get publicDescriptor(): string {
+    return this.#wallet.public_descriptor('external');
+  }
+
   get capabilities(): AccountCapability[] {
     return this.#capabilities;
   }
@@ -197,6 +202,14 @@ export class BdkAccountAdapter implements BitcoinAccount {
         { id: this.#id },
         error,
       );
+    }
+  }
+
+  getUtxo(outpoint: string): LocalOutput | undefined {
+    try {
+      return this.#wallet.get_utxo(OutPoint.from_string(outpoint));
+    } catch (error) {
+      throw new ValidationError('Invalid outpoint', { id: this.#id }, error);
     }
   }
 


### PR DESCRIPTION
Add UTXO management to `submitRequest`:
- get UTXO
- list UTXO
- get public descriptor (helps get all of the addresses of a wallet and perform UTXO selection outside of the wallet), similar to an xPub (but more powerful).