### PR TITLE
feat: confirmation for sign message

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "AUrFbpeVe89u4kqDDz0CULkXZHFNJj199u2SgY3VjW4=",
+    "shasum": "PEAn7SI06NN5ruGNKThpEHR5/fKSRuuS4YLb0oi3bdU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "vRZKNyyxmZPV/QgltpmhtVdUayAjaHKOKIDzBMDod9s=",
+    "shasum": "AUrFbpeVe89u4kqDDz0CULkXZHFNJj199u2SgY3VjW4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/entities/confirmation.ts
+++ b/packages/snap/src/entities/confirmation.ts
@@ -1,0 +1,36 @@
+import type { Network } from '@metamask/bitcoindevkit';
+
+import type { BitcoinAccount } from './account';
+
+export type SignMessageConfirmationContext = {
+  message: string;
+  account: {
+    id: string;
+    address: string; // FIXME: Address should not be needed to identify an account
+  };
+  network: Network;
+  origin: string;
+};
+
+export enum ConfirmationEvent {
+  Confirm = 'confirm',
+  Cancel = 'cancel',
+}
+
+/**
+ * ConfirmationRepository is a repository that manages request confirmations for dApps.
+ */
+export type ConfirmationRepository = {
+  /**
+   * Inserts a sign message confirmation interface.
+   *
+   * @param account - The account to sign the message.
+   * @param message - The message to sign.
+   * @param origin - The origin of the request.
+   */
+  insertSignMessage(
+    account: BitcoinAccount,
+    message: string,
+    origin: string,
+  ): Promise<void>;
+};

--- a/packages/snap/src/entities/confirmation.ts
+++ b/packages/snap/src/entities/confirmation.ts
@@ -13,8 +13,8 @@ export type SignMessageConfirmationContext = {
 };
 
 export enum ConfirmationEvent {
-  Confirm = 'confirm',
-  Cancel = 'cancel',
+  Confirm = 'confirmation-confirm',
+  Cancel = 'confirmation-cancel',
 }
 
 /**

--- a/packages/snap/src/entities/index.ts
+++ b/packages/snap/src/entities/index.ts
@@ -10,3 +10,4 @@ export type * from './translator';
 export type * from './rates';
 export * from './logger';
 export * from './error';
+export * from './confirmation';

--- a/packages/snap/src/handlers/KeyringRequestHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringRequestHandler.test.ts
@@ -463,4 +463,32 @@ describe('KeyringRequestHandler', () => {
       });
     });
   });
+
+  describe('signMessage', () => {
+    const mockRequest = mock<KeyringRequest>({
+      origin,
+      request: {
+        method: AccountCapability.SignMessage,
+        params: {
+          message: 'message',
+        },
+      },
+      account: 'account-id',
+    });
+
+    it('executes publicDescriptor', async () => {
+      mockAccountsUseCases.signMessage.mockResolvedValue('signature');
+      const result = await handler.route(mockRequest);
+
+      expect(mockAccountsUseCases.signMessage).toHaveBeenCalledWith(
+        'account-id',
+        'message',
+        'metamask',
+      );
+      expect(result).toStrictEqual({
+        pending: false,
+        result: { signature: 'signature' },
+      });
+    });
+  });
 });

--- a/packages/snap/src/handlers/KeyringRequestHandler.ts
+++ b/packages/snap/src/handlers/KeyringRequestHandler.ts
@@ -132,7 +132,7 @@ export class KeyringRequestHandler {
       }
       case AccountCapability.SignMessage: {
         assert(params, SignMessageRequest);
-        return this.#signMessage(account, params.message);
+        return this.#signMessage(account, params.message, origin);
       }
       default: {
         throw new InexistentMethodError(
@@ -249,8 +249,16 @@ export class KeyringRequestHandler {
     return this.#toKeyringResponse(account.publicDescriptor);
   }
 
-  async #signMessage(id: string, message: string): Promise<KeyringResponse> {
-    const signature = await this.#accountsUseCases.signMessage(id, message);
+  async #signMessage(
+    id: string,
+    message: string,
+    origin: string,
+  ): Promise<KeyringResponse> {
+    const signature = await this.#accountsUseCases.signMessage(
+      id,
+      message,
+      origin,
+    );
     return this.#toKeyringResponse({
       signature,
     } as SignMessageResponse);

--- a/packages/snap/src/handlers/UserInputHandler.test.ts
+++ b/packages/snap/src/handlers/UserInputHandler.test.ts
@@ -4,17 +4,21 @@ import { mock } from 'jest-mock-extended';
 
 import type { SendFormContext } from '../entities';
 import { ReviewTransactionEvent, SendFormEvent } from '../entities';
-import type { SendFlowUseCases } from '../use-cases';
+import type { ConfirmationUseCases, SendFlowUseCases } from '../use-cases';
 import { UserInputHandler } from './UserInputHandler';
 
 describe('UserInputHandler', () => {
   const mockSendFlowUseCases = mock<SendFlowUseCases>();
+  const mockConfirmationUseCases = mock<ConfirmationUseCases>();
   const mockContext = mock<SendFormContext>();
 
   let handler: UserInputHandler;
 
   beforeEach(() => {
-    handler = new UserInputHandler(mockSendFlowUseCases);
+    handler = new UserInputHandler(
+      mockSendFlowUseCases,
+      mockConfirmationUseCases,
+    );
   });
 
   describe('route', () => {

--- a/packages/snap/src/handlers/UserInputHandler.test.ts
+++ b/packages/snap/src/handlers/UserInputHandler.test.ts
@@ -3,7 +3,11 @@ import { UserInputEventType } from '@metamask/snaps-sdk';
 import { mock } from 'jest-mock-extended';
 
 import type { SendFormContext } from '../entities';
-import { ReviewTransactionEvent, SendFormEvent } from '../entities';
+import {
+  ConfirmationEvent,
+  ReviewTransactionEvent,
+  SendFormEvent,
+} from '../entities';
 import type { ConfirmationUseCases, SendFlowUseCases } from '../use-cases';
 import { UserInputHandler } from './UserInputHandler';
 
@@ -123,6 +127,56 @@ describe('UserInputHandler', () => {
             name: ReviewTransactionEvent.Send,
           },
           mockContext,
+        ),
+      ).rejects.toThrow(error);
+    });
+  });
+
+  describe('handle confirmation', () => {
+    it('executes on confirm', async () => {
+      await handler.route(
+        'interface-id',
+        {
+          type: UserInputEventType.ButtonClickEvent,
+          name: ConfirmationEvent.Confirm,
+        },
+        {},
+      );
+
+      expect(mockConfirmationUseCases.onChange).toHaveBeenCalledWith(
+        'interface-id',
+        ConfirmationEvent.Confirm,
+      );
+    });
+
+    it('executes on cancel', async () => {
+      await handler.route(
+        'interface-id',
+        {
+          type: UserInputEventType.ButtonClickEvent,
+          name: ConfirmationEvent.Cancel,
+        },
+        {},
+      );
+
+      expect(mockConfirmationUseCases.onChange).toHaveBeenCalledWith(
+        'interface-id',
+        ConfirmationEvent.Cancel,
+      );
+    });
+
+    it('propagates errors from onChange', async () => {
+      const error = new Error();
+      mockConfirmationUseCases.onChange.mockRejectedValue(error);
+
+      await expect(
+        handler.route(
+          'interface-id',
+          {
+            type: UserInputEventType.ButtonClickEvent,
+            name: ConfirmationEvent.Cancel,
+          },
+          {},
         ),
       ).rejects.toThrow(error);
     });

--- a/packages/snap/src/handlers/UserInputHandler.ts
+++ b/packages/snap/src/handlers/UserInputHandler.ts
@@ -6,18 +6,22 @@ import type {
 
 import type { ReviewTransactionContext, SendFormContext } from '../entities';
 import {
+  ConfirmationEvent,
   FormatError,
   InexistentMethodError,
   ReviewTransactionEvent,
   SendFormEvent,
 } from '../entities';
-import type { SendFlowUseCases } from '../use-cases';
+import type { ConfirmationUseCases, SendFlowUseCases } from '../use-cases';
 
 export class UserInputHandler {
   readonly #sendFlowUseCases: SendFlowUseCases;
 
-  constructor(sendFlow: SendFlowUseCases) {
+  readonly #confirmationUseCases: ConfirmationUseCases;
+
+  constructor(sendFlow: SendFlowUseCases, confirmation: ConfirmationUseCases) {
     this.#sendFlowUseCases = sendFlow;
+    this.#confirmationUseCases = confirmation;
   }
 
   async route(
@@ -45,6 +49,8 @@ export class UserInputHandler {
         event.name,
         context as ReviewTransactionContext,
       );
+    } else if (this.#isConfirmationEvent(event.name)) {
+      return this.#confirmationUseCases.onChange(interfaceId, event.name);
     }
 
     throw new InexistentMethodError(`Unsupported event: ${event.name}`);
@@ -58,6 +64,10 @@ export class UserInputHandler {
     return Object.values(ReviewTransactionEvent).includes(
       name as ReviewTransactionEvent,
     );
+  }
+
+  #isConfirmationEvent(name: string): name is ConfirmationEvent {
+    return Object.values(ConfirmationEvent).includes(name as ConfirmationEvent);
   }
 
   #hasValue(event: UserInputEvent): event is InputChangeEvent {

--- a/packages/snap/src/handlers/permissions.ts
+++ b/packages/snap/src/handlers/permissions.ts
@@ -1,7 +1,9 @@
 import { PermissionError } from '../entities';
 
+export const METAMASK_ORIGIN = 'metamask';
+
 export const validateOrigin = (origin: string): void => {
-  if (origin !== 'metamask') {
+  if (origin !== METAMASK_ORIGIN) {
     throw new PermissionError('Invalid origin', { origin });
   }
 };

--- a/packages/snap/src/infra/jsx/confirmations/SignMessageConfirmationView.tsx
+++ b/packages/snap/src/infra/jsx/confirmations/SignMessageConfirmationView.tsx
@@ -1,0 +1,101 @@
+import {
+  Address,
+  Box,
+  Button,
+  Container,
+  Footer,
+  Heading,
+  Icon,
+  Section,
+  Text as SnapText,
+  Tooltip,
+  type SnapComponent,
+} from '@metamask/snaps-sdk/jsx';
+
+import type {
+  Messages,
+  SignMessageConfirmationContext,
+} from '../../../entities';
+import { ConfirmationEvent } from '../../../entities';
+import { networkToScope } from '../../../handlers';
+import { AssetIcon } from '../components';
+import { displayCaip10, parseOrigin, translate } from '../format';
+
+type SignMessageConfirmationViewProps = {
+  context: SignMessageConfirmationContext;
+  messages: Messages;
+};
+
+export const SignMessageConfirmationView: SnapComponent<
+  SignMessageConfirmationViewProps
+> = ({ context, messages }) => {
+  const t = translate(messages);
+  const { account, network, origin, message } = context;
+  const originHostname = origin ? parseOrigin(origin) : null;
+
+  return (
+    <Container>
+      <Box>
+        <Box alignment="center" center>
+          <Box>{null}</Box>
+          <Heading size="lg">{t('confirmation.signMessage.title')}</Heading>
+        </Box>
+
+        <Section>
+          <Box direction="horizontal" center>
+            <SnapText fontWeight="medium">
+              {t('confirmation.signMessage.message')}
+            </SnapText>
+          </Box>
+          <Box alignment="space-between">
+            <SnapText>{message}</SnapText>
+          </Box>
+        </Section>
+
+        <Section>
+          {originHostname ? (
+            <Box alignment="space-between" direction="horizontal">
+              <Box alignment="space-between" direction="horizontal" center>
+                <SnapText fontWeight="medium" color="alternative">
+                  {t('confirmation.origin')}
+                </SnapText>
+                <Tooltip content={t('confirmation.origin.tooltip')}>
+                  <Icon name="question" color="muted" />
+                </Tooltip>
+              </Box>
+              <SnapText>{originHostname}</SnapText>
+            </Box>
+          ) : null}
+          <Box alignment="space-between" direction="horizontal">
+            <SnapText fontWeight="medium" color="alternative">
+              {t('confirmation.account')}
+            </SnapText>
+            <Address
+              address={displayCaip10(network, account.address)}
+              displayName
+            />
+          </Box>
+          <Box alignment="space-between" direction="horizontal">
+            <SnapText fontWeight="medium" color="alternative">
+              {t('confirmation.network')}
+            </SnapText>
+            <Box direction="horizontal" alignment="center">
+              <Box alignment="center" center>
+                <AssetIcon network={network} />
+              </Box>
+              <SnapText>{networkToScope[network]}</SnapText>
+            </Box>
+          </Box>
+        </Section>
+      </Box>
+      <Footer>
+        <Button name={ConfirmationEvent.Cancel}>
+          {t('confirmation.cancelButton')}
+        </Button>
+        <Button name={ConfirmationEvent.Confirm}>
+          {t('confirmation.confirmButton')}
+        </Button>
+      </Footer>
+    </Container>
+  );
+};

--- a/packages/snap/src/infra/jsx/confirmations/index.ts
+++ b/packages/snap/src/infra/jsx/confirmations/index.ts
@@ -1,0 +1,1 @@
+export * from './SignMessageConfirmationView';

--- a/packages/snap/src/infra/jsx/format.ts
+++ b/packages/snap/src/infra/jsx/format.ts
@@ -1,7 +1,14 @@
+import type { Network } from '@metamask/bitcoindevkit';
 import { Amount, BdkErrorCode } from '@metamask/bitcoindevkit';
-import type { CurrencyRate } from '@metamask/snaps-sdk';
+import type { CaipAccountId, CurrencyRate } from '@metamask/snaps-sdk';
 
-import type { CurrencyUnit, Messages } from '../../entities';
+import {
+  ValidationError,
+  type CurrencyUnit,
+  type Messages,
+} from '../../entities';
+import { networkToScope } from '../../handlers';
+import { METAMASK_ORIGIN } from '../../handlers/permissions';
 
 export const displayAmount = (
   amountSats: bigint,
@@ -51,4 +58,23 @@ export const errorCodeToLabel = (code: number): string => {
 
   // lowercase the first letter to respect camelCase convention
   return raw.charAt(0).toLowerCase() + raw.slice(1);
+};
+
+export const parseOrigin = (origin: string): string => {
+  if (origin === METAMASK_ORIGIN) {
+    return 'MetaMask';
+  }
+
+  try {
+    return new URL(origin).hostname;
+  } catch (error) {
+    throw new ValidationError('Invalid URL', { origin }, error);
+  }
+};
+
+export const displayCaip10 = (
+  network: Network,
+  address: string,
+): CaipAccountId => {
+  return `${networkToScope[network]}:${address}`;
 };

--- a/packages/snap/src/infra/jsx/index.ts
+++ b/packages/snap/src/infra/jsx/index.ts
@@ -1,2 +1,2 @@
-export * from './SendFormView';
-export * from './ReviewTransactionView';
+export * from './send-flow';
+export * from './confirmations';

--- a/packages/snap/src/infra/jsx/send-flow/ReviewTransactionView.tsx
+++ b/packages/snap/src/infra/jsx/send-flow/ReviewTransactionView.tsx
@@ -13,23 +13,22 @@ import {
   Address,
   Link,
 } from '@metamask/snaps-sdk/jsx';
-import type { CaipAccountId } from '@metamask/utils';
 
-import { AssetIcon, HeadingWithReturn } from './components';
-import {
-  displayAmount,
-  displayExchangeAmount,
-  displayExplorerUrl,
-  translate,
-} from './format';
-import { Config } from '../../config';
-import type { Messages, ReviewTransactionContext } from '../../entities';
+import { Config } from '../../../config';
+import type { Messages, ReviewTransactionContext } from '../../../entities';
 import {
   BlockTime,
   networkToCurrencyUnit,
   ReviewTransactionEvent,
-} from '../../entities';
-import { networkToScope } from '../../handlers';
+} from '../../../entities';
+import { AssetIcon, HeadingWithReturn } from '../components';
+import {
+  displayAmount,
+  displayCaip10,
+  displayExchangeAmount,
+  displayExplorerUrl,
+  translate,
+} from '../format';
 
 type ReviewTransactionViewProps = {
   context: ReviewTransactionContext;
@@ -68,18 +67,13 @@ export const ReviewTransactionView: SnapComponent<
         <Section>
           <Row label={t('from')}>
             <Link href={displayExplorerUrl(explorerUrl, from)}>
-              <Address
-                address={`${networkToScope[network]}:${from}` as CaipAccountId}
-                displayName
-              />
+              <Address address={displayCaip10(network, from)} displayName />
             </Link>
           </Row>
           <Row label={t('recipient')}>
             <Link href={displayExplorerUrl(explorerUrl, recipient)}>
               <Address
-                address={
-                  `${networkToScope[network]}:${recipient}` as CaipAccountId
-                }
+                address={displayCaip10(network, recipient)}
                 displayName
               />
             </Link>

--- a/packages/snap/src/infra/jsx/send-flow/SendFormView.tsx
+++ b/packages/snap/src/infra/jsx/send-flow/SendFormView.tsx
@@ -8,10 +8,10 @@ import {
   Text as SnapText,
 } from '@metamask/snaps-sdk/jsx';
 
-import { HeadingWithReturn, SendForm } from './components';
-import { errorCodeToLabel, translate } from './format';
-import type { Messages, SendFormContext } from '../../entities';
-import { SendFormEvent } from '../../entities';
+import type { Messages, SendFormContext } from '../../../entities';
+import { SendFormEvent } from '../../../entities';
+import { HeadingWithReturn, SendForm } from '../components';
+import { errorCodeToLabel, translate } from '../format';
 
 export type SendFormViewProps = {
   context: SendFormContext;

--- a/packages/snap/src/infra/jsx/send-flow/index.ts
+++ b/packages/snap/src/infra/jsx/send-flow/index.ts
@@ -1,0 +1,2 @@
+export * from './SendFormView';
+export * from './ReviewTransactionView';

--- a/packages/snap/src/store/JSXConfirmationRepository.test.tsx
+++ b/packages/snap/src/store/JSXConfirmationRepository.test.tsx
@@ -1,0 +1,70 @@
+import type { Address } from '@metamask/bitcoindevkit';
+import type { GetPreferencesResult } from '@metamask/snaps-sdk';
+import { mock } from 'jest-mock-extended';
+
+import type { SnapClient, Translator, BitcoinAccount } from '../entities';
+import { JSXConfirmationRepository } from './JSXConfirmationRepository';
+import { SignMessageConfirmationView } from '../infra/jsx';
+
+jest.mock('../infra/jsx', () => ({
+  SignMessageConfirmationView: jest.fn(),
+}));
+
+describe('JSXConfirmationRepository', () => {
+  const mockMessages = { foo: { message: 'bar' } };
+  const mockSnapClient = mock<SnapClient>();
+  const mockTranslator = mock<Translator>();
+
+  const repo = new JSXConfirmationRepository(mockSnapClient, mockTranslator);
+
+  describe('insertSignMessage', () => {
+    const mockAccount = mock<BitcoinAccount>({
+      id: 'account-id',
+      publicAddress: mock<Address>({ toString: () => 'myAddress' }),
+    });
+    const message = 'message';
+    const origin = 'origin';
+    const expectedContext = {
+      message,
+      origin,
+      account: {
+        id: mockAccount.id,
+        address: mockAccount.publicAddress.toString(),
+      },
+      network: mockAccount.network,
+    };
+
+    beforeEach(() => {
+      mockSnapClient.createInterface.mockResolvedValue('interface-id');
+      mockSnapClient.displayInterface.mockResolvedValue(true);
+      mockTranslator.load.mockResolvedValue(mockMessages);
+      mockSnapClient.getPreferences.mockResolvedValue({
+        locale: 'en',
+      } as GetPreferencesResult);
+    });
+
+    it('creates and displays a sign message interface', async () => {
+      await repo.insertSignMessage(mockAccount, message, origin);
+
+      expect(mockSnapClient.getPreferences).toHaveBeenCalled();
+      expect(mockSnapClient.createInterface).toHaveBeenCalledWith(
+        <SignMessageConfirmationView
+          context={expectedContext}
+          messages={mockMessages}
+        />,
+        expectedContext,
+      );
+      expect(mockTranslator.load).toHaveBeenCalledWith('en');
+      expect(mockSnapClient.displayInterface).toHaveBeenCalledWith(
+        'interface-id',
+      );
+    });
+
+    it('throws UserActionError if the interface returns false', async () => {
+      mockSnapClient.displayInterface.mockResolvedValue(false);
+      await expect(
+        repo.insertSignMessage(mockAccount, message, origin),
+      ).rejects.toThrow('User canceled the confirmation');
+    });
+  });
+});

--- a/packages/snap/src/store/JSXConfirmationRepository.tsx
+++ b/packages/snap/src/store/JSXConfirmationRepository.tsx
@@ -1,0 +1,51 @@
+import type {
+  BitcoinAccount,
+  ConfirmationRepository,
+  SignMessageConfirmationContext,
+  SnapClient,
+  Translator,
+} from '../entities';
+import { UserActionError } from '../entities';
+import { SignMessageConfirmationView } from '../infra/jsx';
+
+export class JSXConfirmationRepository implements ConfirmationRepository {
+  readonly #snapClient: SnapClient;
+
+  readonly #translator: Translator;
+
+  constructor(snapClient: SnapClient, translator: Translator) {
+    this.#snapClient = snapClient;
+    this.#translator = translator;
+  }
+
+  async insertSignMessage(
+    account: BitcoinAccount,
+    message: string,
+    origin: string,
+  ): Promise<void> {
+    const { locale } = await this.#snapClient.getPreferences();
+    const context: SignMessageConfirmationContext = {
+      message,
+      origin,
+      account: {
+        id: account.id,
+        address: account.publicAddress.toString(), // FIXME: Address should not be needed in the send flow
+      },
+      network: account.network,
+    };
+
+    const messages = await this.#translator.load(locale);
+    const interfaceId = await this.#snapClient.createInterface(
+      <SignMessageConfirmationView context={context} messages={messages} />,
+      context,
+    );
+
+    // Blocks and waits for user actions. This logic can live here instead of in the use case
+    // because it's common to all confirmations. Move to use case if needed.
+    const confirmed =
+      await this.#snapClient.displayInterface<boolean>(interfaceId);
+    if (!confirmed) {
+      throw new UserActionError('User canceled the confirmation');
+    }
+  }
+}

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -18,6 +18,7 @@ import type {
   BitcoinAccount,
   BitcoinAccountRepository,
   BlockchainClient,
+  ConfirmationRepository,
   Inscription,
   Logger,
   MetaProtocolsClient,
@@ -39,6 +40,7 @@ describe('AccountUseCases', () => {
   const mockLogger = mock<Logger>();
   const mockSnapClient = mock<SnapClient>();
   const mockRepository = mock<BitcoinAccountRepository>();
+  const mockConfirmationRepository = mock<ConfirmationRepository>();
   const mockChain = mock<BlockchainClient>();
   const mockMetaProtocols = mock<MetaProtocolsClient>();
   const fallbackFeeRate = 5.0;
@@ -48,6 +50,7 @@ describe('AccountUseCases', () => {
     mockLogger,
     mockSnapClient,
     mockRepository,
+    mockConfirmationRepository,
     mockChain,
     fallbackFeeRate,
     targetBlocksConfirmation,
@@ -636,6 +639,7 @@ describe('AccountUseCases', () => {
         mockLogger,
         mockSnapClient,
         mockRepository,
+        mockConfirmationRepository,
         mockChain,
         fallbackFeeRate,
         targetBlocksConfirmation,
@@ -719,6 +723,7 @@ describe('AccountUseCases', () => {
         mockLogger,
         mockSnapClient,
         mockRepository,
+        mockConfirmationRepository,
         mockChain,
         fallbackFeeRate,
         targetBlocksConfirmation,
@@ -1374,6 +1379,7 @@ describe('AccountUseCases', () => {
       derivationPath: ['m', "84'", "0'"],
     });
     const mockMessage = 'Hello, world!';
+    const mockOrigin = 'metamask';
 
     beforeEach(() => {
       mockRepository.get.mockResolvedValue(mockAccount);
@@ -1387,7 +1393,7 @@ describe('AccountUseCases', () => {
       mockRepository.get.mockResolvedValue(null);
 
       await expect(
-        useCases.signMessage('non-existent-id', mockMessage),
+        useCases.signMessage('non-existent-id', mockMessage, mockOrigin),
       ).rejects.toThrow('Account not found');
     });
 
@@ -1395,7 +1401,11 @@ describe('AccountUseCases', () => {
       const expectedSignature =
         'AkcwRAIgZxodJQ60t9Rr/hABEHZ1zPUJ4m5hdM5QLpysH8fDSzgCIENOEuZtYf9/Nn/ZW15PcImkknol403dmZrgoOQ+6K+TASECwDKypXm/ElmVTxTLJ7nao6X5mB/iGbU2Q2qtot0QRL4=';
 
-      const signature = await useCases.signMessage('account-id', mockMessage);
+      const signature = await useCases.signMessage(
+        'account-id',
+        mockMessage,
+        mockOrigin,
+      );
 
       expect(mockRepository.get).toHaveBeenCalledWith('account-id');
       expect(mockSnapClient.getPrivateEntropy).toHaveBeenCalledWith([
@@ -1414,7 +1424,7 @@ describe('AccountUseCases', () => {
       } as JsonSLIP10Node);
 
       await expect(
-        useCases.signMessage('account-id', mockMessage),
+        useCases.signMessage('account-id', mockMessage, mockOrigin),
       ).rejects.toThrow('Failed to sign message');
     });
 
@@ -1423,7 +1433,7 @@ describe('AccountUseCases', () => {
       mockRepository.get.mockRejectedValueOnce(error);
 
       await expect(
-        useCases.signMessage('account-id', mockMessage),
+        useCases.signMessage('account-id', mockMessage, mockOrigin),
       ).rejects.toBe(error);
     });
 
@@ -1432,7 +1442,7 @@ describe('AccountUseCases', () => {
       mockSnapClient.getPrivateEntropy.mockRejectedValue(error);
 
       await expect(
-        useCases.signMessage('account-id', mockMessage),
+        useCases.signMessage('account-id', mockMessage, mockOrigin),
       ).rejects.toBe(error);
     });
   });

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -1415,6 +1415,11 @@ describe('AccountUseCases', () => {
         '0',
         '0',
       ]);
+      expect(mockConfirmationRepository.insertSignMessage).toHaveBeenCalledWith(
+        mockAccount,
+        mockMessage,
+        mockOrigin,
+      );
       expect(signature).toBe(expectedSignature);
     });
 

--- a/packages/snap/src/use-cases/ConfirmationUseCases.test.ts
+++ b/packages/snap/src/use-cases/ConfirmationUseCases.test.ts
@@ -1,0 +1,44 @@
+import { mock } from 'jest-mock-extended';
+
+import { ConfirmationEvent, type Logger, type SnapClient } from '../entities';
+import { ConfirmationUseCases } from './ConfirmationUseCases';
+
+describe('ConfirmationUseCases', () => {
+  const mockLogger = mock<Logger>();
+  const mockSnapClient = mock<SnapClient>();
+
+  const useCases = new ConfirmationUseCases(mockLogger, mockSnapClient);
+
+  describe('onChange', () => {
+    it('interface resolves to false on cancel', async () => {
+      await useCases.onChange('interface-id', ConfirmationEvent.Cancel);
+      expect(mockSnapClient.resolveInterface).toHaveBeenCalledWith(
+        'interface-id',
+        false,
+      );
+    });
+
+    it('interface resolves to true on confirm', async () => {
+      await useCases.onChange('interface-id', ConfirmationEvent.Confirm);
+      expect(mockSnapClient.resolveInterface).toHaveBeenCalledWith(
+        'interface-id',
+        true,
+      );
+    });
+
+    it('throws an error if the event is not recognized', async () => {
+      await expect(
+        useCases.onChange('interface-id', 'unknown' as ConfirmationEvent),
+      ).rejects.toThrow('Unrecognized confirmation event');
+    });
+
+    it('propagates an error if resolveInterface fails', async () => {
+      const error = new Error('resolveInterface failed');
+      mockSnapClient.resolveInterface.mockRejectedValue(error);
+
+      await expect(
+        useCases.onChange('interface-id', ConfirmationEvent.Cancel),
+      ).rejects.toBe(error);
+    });
+  });
+});

--- a/packages/snap/src/use-cases/ConfirmationUseCases.ts
+++ b/packages/snap/src/use-cases/ConfirmationUseCases.ts
@@ -1,0 +1,32 @@
+import type { SnapClient, Logger } from '../entities';
+import { UserActionError, ConfirmationEvent } from '../entities';
+
+export class ConfirmationUseCases {
+  readonly #logger: Logger;
+
+  readonly #snapClient: SnapClient;
+
+  constructor(logger: Logger, snapClient: SnapClient) {
+    this.#logger = logger;
+    this.#snapClient = snapClient;
+  }
+
+  async onChange(id: string, event: ConfirmationEvent): Promise<void> {
+    this.#logger.debug(
+      'Event triggered on confirmation: %s. Event: %s',
+      id,
+      event,
+    );
+
+    switch (event) {
+      case ConfirmationEvent.Cancel: {
+        return this.#snapClient.resolveInterface(id, false);
+      }
+      case ConfirmationEvent.Confirm: {
+        return this.#snapClient.resolveInterface(id, true);
+      }
+      default:
+        throw new UserActionError('Unrecognized confirmation event');
+    }
+  }
+}

--- a/packages/snap/src/use-cases/ConfirmationUseCases.ts
+++ b/packages/snap/src/use-cases/ConfirmationUseCases.ts
@@ -11,19 +11,19 @@ export class ConfirmationUseCases {
     this.#snapClient = snapClient;
   }
 
-  async onChange(id: string, event: ConfirmationEvent): Promise<void> {
+  async onChange(interfaceId: string, event: ConfirmationEvent): Promise<void> {
     this.#logger.debug(
       'Event triggered on confirmation: %s. Event: %s',
-      id,
+      interfaceId,
       event,
     );
 
     switch (event) {
       case ConfirmationEvent.Cancel: {
-        return this.#snapClient.resolveInterface(id, false);
+        return this.#snapClient.resolveInterface(interfaceId, false);
       }
       case ConfirmationEvent.Confirm: {
-        return this.#snapClient.resolveInterface(id, true);
+        return this.#snapClient.resolveInterface(interfaceId, true);
       }
       default:
         throw new UserActionError('Unrecognized confirmation event');

--- a/packages/snap/src/use-cases/index.ts
+++ b/packages/snap/src/use-cases/index.ts
@@ -1,3 +1,4 @@
 export * from './AccountUseCases';
 export * from './SendFlowUseCases';
 export * from './AssetsUseCases';
+export * from './ConfirmationUseCases';


### PR DESCRIPTION
Add confirmation for `signMessage` flow. This being the first confimration, it add all the boilerplate for them such as the Repository, the use cases and the folders.