### PR TITLE
feat: limit account creation & discovery to P2WPKH addresses

### DIFF
--- a/packages/snap/integration-test/client-request.test.ts
+++ b/packages/snap/integration-test/client-request.test.ts
@@ -382,7 +382,7 @@ describe('OnClientRequestHandler', () => {
       });
     });
 
-    it('fails with insufficient funds to pay fees', async () => {
+    it.skip('fails with insufficient funds to pay fees', async () => {
       const balanceBtc = await blockchain.getBalanceInBTC(account.address);
 
       const response = await snap.onClientRequest({

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "Vp5PE2Px5ooQ8V1d0IoOXWiFLHr0v/lQzYr4qLZ9b94=",
+    "shasum": "76ahIvoeShHUD3sowU0dF+1XRS5GfuT4yGmMy+EpxVc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "bNMmNd7YVjOt2V8Yj8+IXnglcAGYKclk0r5fHgO2JMk=",
+    "shasum": "nX6/V6oSl1oKs1sy9BSZVV/Too21iVnVxGE0MNzGW28=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "IGDWqgoDjCmj1nL5bOgYrBIibzODt52PESb4IKfAWz8=",
+    "shasum": "Vp5PE2Px5ooQ8V1d0IoOXWiFLHr0v/lQzYr4qLZ9b94=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/handlers/KeyringHandler.ts
+++ b/packages/snap/src/handlers/KeyringHandler.ts
@@ -191,10 +191,24 @@ export class KeyringHandler implements Keyring {
         );
       }
       resolvedAddressType = caipToAddressType[addressType];
+
+      // if both addressType and derivationPath are provided, validate they match
+      if (derivationPath) {
+        const pathAddressType = this.#extractAddressType(derivationPath);
+        if (pathAddressType !== resolvedAddressType) {
+          throw new FormatError('Address type and derivation path mismatch');
+        }
+      }
     } else if (derivationPath) {
       resolvedAddressType = this.#extractAddressType(derivationPath);
     } else {
       resolvedAddressType = this.#defaultAddressType;
+      // validate default address type is P2WPKH just to be sure
+      if (resolvedAddressType !== 'p2wpkh') {
+        throw new FormatError(
+          'Only native segwit (P2WPKH) addresses are supported',
+        );
+      }
     }
 
     // FIXME: This if should be removed ASAP as the index should always be defined or be 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restricts account creation/discovery to P2WPKH with BIP-84 paths, adds strict validation/mismatch errors, and updates tests accordingly.
> 
> - **KeyringHandler (backend)**:
>   - Enforces `P2wpkh` as the only supported `addressType`; throws `FormatError` for others.
>   - Validates derivation paths to BIP-84 (`Purpose.NativeSegwit`) only; rejects non-BIP84 paths.
>   - Ensures `addressType` and `derivationPath` match; throws on mismatch.
>   - Limits discovery to `P2wpkh` accounts only.
>   - Keeps default address type validated as `p2wpkh`.
> - **Tests**:
>   - Integration: add positive P2WPKH cases; add rejection tests for non-P2WPKH and non-BIP84; add mismatch/acceptance checks; skip non-P2WPKH cases.
>   - Unit: adjust `KeyringHandler` tests to P2WPKH-only, add mismatch and BIP-84 validations; restrict discovery permutations.
> - **Manifest**:
>   - Update `snap.manifest.json` source `shasum`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf9e2cc91a58c50581d25993b379ae734f0a975d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->