### PR TITLE
fix: fix `keyring_createAccount` idempotency

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Manage Bitcoin using MetaMask",
   "proposedName": "Bitcoin",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "j9W3ulkpAGrL0lkkChX7wavGEY3qq6nCf4lQ0KmmF78=",
+    "shasum": "vYuBEE/FcdT9Tx0+bRSQd82dwye4KmkSMiC46aMOqvU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/use-cases/AccountUseCases.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.ts
@@ -166,11 +166,6 @@ export class AccountUseCases {
     const account = await this.#repository.getByDerivationPath(derivationPath);
     if (account && account.network === network) {
       this.#logger.debug('Account already exists: %s,', account.id);
-      await this.#snapClient.emitAccountCreatedEvent(
-        account,
-        correlationId,
-        accountName,
-      );
       return account;
     }
 


### PR DESCRIPTION
The `notify:accountCreated` event was fired even for existing accounts, which would cause errors in the `SnapKeyring` handling (if the account has not been created already):
- https://github.com/MetaMask/accounts/blob/v79.0.0/packages/keyring-snap-bridge/src/SnapKeyring.ts#L342-L354

Similarly to the Solana Snap, if the account already exists, we just return the `KeyringAccount` object and that's it:
- https://github.com/MetaMask/snap-solana-wallet/blob/main/packages/snap/src/core/handlers/onKeyringRequest/Keyring.ts#L229-L244

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop emitting accountCreated when the account already exists; bump Snap version to 1.6.0.
> 
> - **Core (snap)**:
>   - `AccountUseCases.create`: Return existing account without emitting `accountCreated` to ensure idempotency.
> - **Manifest**:
>   - Bump `packages/snap/snap.manifest.json` version to `1.6.0` and update `source.shasum`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d57dc395e0e6b441a8b0bdc588c0ed0533b4fcdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->