### PR TITLE
refactor: move validation structs and add account field

### DIFF
--- a/packages/snap/integration-test/keyring-request.test.ts
+++ b/packages/snap/integration-test/keyring-request.test.ts
@@ -167,6 +167,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.GetUtxo,
             params: {
+              account: { address: account.address },
               outpoint: utxos[0]?.outpoint,
             },
           },
@@ -221,6 +222,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
               options: {
@@ -253,6 +255,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
               options: {
@@ -285,6 +288,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
               options: {
@@ -317,6 +321,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: 'notAPsbt',
               options: {
                 fill: true,
@@ -350,6 +355,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
             },
           },
@@ -382,6 +388,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.FillPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
             },
@@ -409,6 +416,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.FillPsbt,
             params: {
+              account: { address: account.address },
               psbt: 'notAPsbt',
             },
           },
@@ -444,6 +452,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.ComputeFee,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
             },
@@ -471,6 +480,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.ComputeFee,
             params: {
+              account: { address: account.address },
               psbt: 'notAPsbt',
             },
           },
@@ -507,6 +517,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
               options: {
@@ -533,6 +544,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.BroadcastPsbt,
             params: {
+              account: { address: account.address },
               psbt: result.psbt,
             },
           },
@@ -559,6 +571,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.BroadcastPsbt,
             params: {
+              account: { address: account.address },
               psbt: 'notAPsbt',
             },
           },
@@ -590,6 +603,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SendTransfer,
             params: {
+              account: { address: account.address },
               recipients: [
                 {
                   address: 'bcrt1qstku2y3pfh9av50lxj55arm8r5gj8tf2yv5nxz',
@@ -626,6 +640,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SendTransfer,
             params: {
+              account: { address: account.address },
               recipients: [{ address: 'notAnAddress', amount: '1000' }],
             },
           },
@@ -654,6 +669,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignMessage,
             params: {
+              account: { address: account.address },
               message: 'Hello, world!',
             },
           },

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "o9ZJmt7WEmIOXnmPlqmqRbGWztcCkDTKkW2VaBza56E=",
+    "shasum": "Ph0Ibbk8XLQfwi4HRKZx4SQ3itVjUHsMVQG/+/HIHbE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/handlers/KeyringRequestHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringRequestHandler.test.ts
@@ -4,20 +4,26 @@ import { mock } from 'jest-mock-extended';
 import { assert } from 'superstruct';
 
 import type { AccountUseCases } from '../use-cases';
+import { KeyringRequestHandler } from './KeyringRequestHandler';
 import {
   BroadcastPsbtRequest,
   ComputeFeeRequest,
   FillPsbtRequest,
   GetUtxoRequest,
-  KeyringRequestHandler,
   SendTransferRequest,
   SignPsbtRequest,
-} from './KeyringRequestHandler';
+} from './validation';
 import type { BitcoinAccount } from '../entities';
 import { AccountCapability } from '../entities';
 import type { Utxo } from './mappings';
 import { mapToUtxo } from './mappings';
 import { parsePsbt } from './parsers';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+jest.mock('@metamask/bitcoindevkit', () => ({
+  Address: { from_string: jest.fn() },
+  Amount: { from_btc: jest.fn() },
+}));
 
 jest.mock('superstruct', () => ({
   ...jest.requireActual('superstruct'),
@@ -35,6 +41,11 @@ jest.mock('./mappings', () => ({
 describe('KeyringRequestHandler', () => {
   const mockAccountsUseCases = mock<AccountUseCases>();
   const origin = 'metamask';
+
+  const ACCOUNT_ADDRESS = 'test-account-address';
+  const accountParam = {
+    account: { address: ACCOUNT_ADDRESS },
+  };
 
   const handler = new KeyringRequestHandler(mockAccountsUseCases);
 
@@ -65,6 +76,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.SignPsbt,
         params: {
+          ...accountParam,
           psbt: 'psbtBase64',
           feeRate: 3,
           options: mockOptions,
@@ -109,7 +121,10 @@ describe('KeyringRequestHandler', () => {
       await expect(
         handler.route({
           ...mockRequest,
-          request: { ...mockRequest.request, params: { psbt: 'invalidPsbt' } },
+          request: {
+            ...mockRequest.request,
+            params: { ...accountParam, psbt: 'invalidPsbt' },
+          },
         }),
       ).rejects.toThrow(error);
 
@@ -131,6 +146,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.ComputeFee,
         params: {
+          ...accountParam,
           psbt: 'psbtBase64',
           feeRate: 3,
         },
@@ -141,7 +157,6 @@ describe('KeyringRequestHandler', () => {
     it('executes computeFee', async () => {
       mockAccountsUseCases.computeFee.mockResolvedValue(
         mock<Amount>({
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           to_sat: () => BigInt(1000),
         }),
       );
@@ -172,7 +187,10 @@ describe('KeyringRequestHandler', () => {
       await expect(
         handler.route({
           ...mockRequest,
-          request: { ...mockRequest.request, params: { psbt: 'invalidPsbt' } },
+          request: {
+            ...mockRequest.request,
+            params: { ...accountParam, psbt: 'invalidPsbt' },
+          },
         }),
       ).rejects.toThrow(error);
 
@@ -194,6 +212,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.FillPsbt,
         params: {
+          ...accountParam,
           psbt: 'psbtBase64',
           feeRate: 3,
         },
@@ -233,7 +252,10 @@ describe('KeyringRequestHandler', () => {
       await expect(
         handler.route({
           ...mockRequest,
-          request: { ...mockRequest.request, params: { psbt: 'invalidPsbt' } },
+          request: {
+            ...mockRequest.request,
+            params: { ...accountParam, psbt: 'invalidPsbt' },
+          },
         }),
       ).rejects.toThrow(error);
 
@@ -256,6 +278,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.BroadcastPsbt,
         params: {
+          ...accountParam,
           psbt: 'psbtBase64',
           feeRate: 3,
         },
@@ -295,7 +318,10 @@ describe('KeyringRequestHandler', () => {
       await expect(
         handler.route({
           ...mockRequest,
-          request: { ...mockRequest.request, params: { psbt: 'invalidPsbt' } },
+          request: {
+            ...mockRequest.request,
+            params: { ...accountParam, psbt: 'invalidPsbt' },
+          },
         }),
       ).rejects.toThrow(error);
 
@@ -324,6 +350,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.SendTransfer,
         params: {
+          ...accountParam,
           recipients,
           feeRate: 3,
         },
@@ -376,6 +403,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.GetUtxo,
         params: {
+          ...accountParam,
           outpoint: 'mytxid:0',
         },
       },
@@ -470,6 +498,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.SignMessage,
         params: {
+          ...accountParam,
           message: 'message',
         },
       },

--- a/packages/snap/src/handlers/KeyringRequestHandler.ts
+++ b/packages/snap/src/handlers/KeyringRequestHandler.ts
@@ -1,14 +1,6 @@
 import type { KeyringRequest, KeyringResponse } from '@metamask/keyring-api';
 import type { Json } from '@metamask/snaps-sdk';
-import {
-  array,
-  assert,
-  boolean,
-  number,
-  object,
-  optional,
-  string,
-} from 'superstruct';
+import { assert } from 'superstruct';
 
 import {
   AccountCapability,
@@ -17,66 +9,34 @@ import {
 } from '../entities';
 import { mapToUtxo } from './mappings';
 import { parsePsbt } from './parsers';
+import {
+  BroadcastPsbtRequest,
+  ComputeFeeRequest,
+  FillPsbtRequest,
+  GetUtxoRequest,
+  SendTransferRequest,
+  SignMessageRequest,
+  SignPsbtRequest,
+} from './validation';
 import type { AccountUseCases } from '../use-cases/AccountUseCases';
-
-export const SignPsbtRequest = object({
-  psbt: string(),
-  feeRate: optional(number()),
-  options: object({
-    fill: boolean(),
-    broadcast: boolean(),
-  }),
-});
 
 export type SignPsbtResponse = {
   psbt: string;
   txid: string | null;
 };
 
-export const ComputeFeeRequest = object({
-  psbt: string(),
-  feeRate: optional(number()),
-});
-
 export type ComputeFeeResponse = {
   // Fee in satoshis
   fee: string;
 };
 
-export const BroadcastPsbtRequest = object({
-  psbt: string(),
-});
-
 export type BroadcastPsbtResponse = {
   txid: string;
 };
 
-export const FillPsbtRequest = object({
-  psbt: string(),
-  feeRate: optional(number()),
-});
-
 export type FillPsbtResponse = {
   psbt: string;
 };
-
-export const SendTransferRequest = object({
-  recipients: array(
-    object({
-      address: string(),
-      amount: string(),
-    }),
-  ),
-  feeRate: optional(number()),
-});
-
-export const GetUtxoRequest = object({
-  outpoint: string(),
-});
-
-export const SignMessageRequest = object({
-  message: string(),
-});
 
 export type SignMessageResponse = {
   signature: string;

--- a/packages/snap/src/handlers/caip.ts
+++ b/packages/snap/src/handlers/caip.ts
@@ -1,5 +1,6 @@
 import type { AddressType, Network } from '@metamask/bitcoindevkit';
 import { BtcAccountType, BtcScope } from '@metamask/keyring-api';
+import { enums } from 'superstruct';
 
 const reverseMapping = <
   From extends string | number | symbol,
@@ -36,6 +37,8 @@ export enum Caip19Asset {
   Signet = 'bip122:00000008819873e925422c1ff0f99f7c/slip44:0',
   Regtest = 'bip122:regtest/slip44:0',
 }
+
+export const NetworkStruct = enums(Object.values(BtcScope));
 
 export const networkToCaip19: Record<Network, Caip19Asset> = {
   bitcoin: Caip19Asset.Bitcoin,

--- a/packages/snap/src/handlers/validation.ts
+++ b/packages/snap/src/handlers/validation.ts
@@ -92,7 +92,6 @@ export const NO_ERRORS_RESPONSE: ValidationResponse = {
   errors: [],
 };
 
-
 /**
  * Wallet account struct for Bitcoin requests.
  */

--- a/packages/snap/src/handlers/validation.ts
+++ b/packages/snap/src/handlers/validation.ts
@@ -199,8 +199,6 @@ export const BtcWalletRequestStruct = union([
   SignMessageKeyringRequestStruct,
 ]);
 
-export type BtcWalletRequest = Infer<typeof BtcWalletRequestStruct>;
-
 /**
  * Validates that an amount is a positive number
  *

--- a/packages/snap/src/handlers/validation.ts
+++ b/packages/snap/src/handlers/validation.ts
@@ -1,5 +1,6 @@
 import type { Network, AddressType } from '@metamask/bitcoindevkit';
 import { Address, Amount } from '@metamask/bitcoindevkit';
+import { BtcMethod } from '@metamask/keyring-api';
 import { CaipAssetTypeStruct } from '@metamask/utils';
 import type { Infer } from 'superstruct';
 import {
@@ -7,10 +8,14 @@ import {
   array,
   boolean,
   enums,
+  literal,
+  number,
   object,
+  optional,
   string,
   nonempty,
   refine,
+  union,
   is,
 } from 'superstruct';
 
@@ -86,6 +91,116 @@ export const NO_ERRORS_RESPONSE: ValidationResponse = {
   valid: true,
   errors: [],
 };
+
+
+/**
+ * Wallet account struct for Bitcoin requests.
+ */
+const WalletAccountStruct = object({
+  address: string(),
+});
+
+export const SignPsbtRequest = object({
+  account: WalletAccountStruct,
+  psbt: string(),
+  feeRate: optional(number()),
+  options: object({
+    fill: boolean(),
+    broadcast: boolean(),
+  }),
+});
+
+export const ComputeFeeRequest = object({
+  account: WalletAccountStruct,
+  psbt: string(),
+  feeRate: optional(number()),
+});
+
+export const BroadcastPsbtRequest = object({
+  account: WalletAccountStruct,
+  psbt: string(),
+});
+
+export const FillPsbtRequest = object({
+  account: WalletAccountStruct,
+  psbt: string(),
+  feeRate: optional(number()),
+});
+
+export const SendTransferRequest = object({
+  account: WalletAccountStruct,
+  recipients: array(
+    object({
+      address: string(),
+      amount: string(),
+    }),
+  ),
+  feeRate: optional(number()),
+});
+
+export const GetUtxoRequest = object({
+  account: WalletAccountStruct,
+  outpoint: string(),
+});
+
+export const SignMessageRequest = object({
+  account: WalletAccountStruct,
+  message: string(),
+});
+
+/**
+ * Validates that a JsonRpcRequest is a valid Bitcoin request.
+ *
+ * TODO: update btc-methods.md to include all the new methods
+ *
+ * @see https://github.com/MetaMask/accounts/blob/main/packages/keyring-api/docs/btc-methods.md
+ */
+export const SignPsbtKeyringRequestStruct = object({
+  method: literal(BtcMethod.SignPsbt),
+  params: SignPsbtRequest,
+});
+
+export const FillPsbtKeyringRequestStruct = object({
+  method: literal(BtcMethod.FillPsbt),
+  params: FillPsbtRequest,
+});
+
+export const ComputeFeeKeyringRequestStruct = object({
+  method: literal(BtcMethod.ComputeFee),
+  params: ComputeFeeRequest,
+});
+
+export const BroadcastPsbtKeyringRequestStruct = object({
+  method: literal(BtcMethod.BroadcastPsbt),
+  params: BroadcastPsbtRequest,
+});
+
+export const SendTransferKeyringRequestStruct = object({
+  method: literal(BtcMethod.SendTransfer),
+  params: SendTransferRequest,
+});
+
+export const GetUtxoKeyringRequestStruct = object({
+  method: literal(BtcMethod.GetUtxo),
+  params: GetUtxoRequest,
+});
+
+export const SignMessageKeyringRequestStruct = object({
+  method: literal(BtcMethod.SignMessage),
+  params: SignMessageRequest,
+});
+
+export const BtcWalletRequestStruct = union([
+  SignPsbtKeyringRequestStruct,
+  FillPsbtKeyringRequestStruct,
+  ComputeFeeKeyringRequestStruct,
+  BroadcastPsbtKeyringRequestStruct,
+  SendTransferKeyringRequestStruct,
+  GetUtxoKeyringRequestStruct,
+  SignMessageKeyringRequestStruct,
+]);
+
+export type BtcWalletRequest = Infer<typeof BtcWalletRequestStruct>;
 
 /**
  * Validates that an amount is a positive number


### PR DESCRIPTION
## Explanation
This PR contributes to supporting the Bitcoin dApp connectivity.
It's refactoring the current code to prepare the integration of the resolve account address Keyring method.

It is part from the initial PR [#564 feat: enable account address resolution to support dApps connectivity](https://github.com/MetaMask/snap-bitcoin-wallet/pull/564) to split the work into 3 smaller PRs:
[#589 refactor: move validation structs and add account field](https://github.com/MetaMask/snap-bitcoin-wallet/pull/589)
[#590 feat: add resolveAccountAddress method to KeyringHandler for dApp connectivity routing](https://github.com/MetaMask/snap-bitcoin-wallet/pull/590)
[#591 feat: add confirmation dialog before sendTransfer and before signing a PSBT from the keyring handler](https://github.com/MetaMask/snap-bitcoin-wallet/pull/591)

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the validated shape of keyring request params (adds required `account.address` and method-specific structs), which can break callers if they haven’t been updated; logic changes are mostly limited to validation and tests.
> 
> **Overview**
> **Refactors Bitcoin keyring request validation** by moving the request `superstruct` schemas out of `KeyringRequestHandler` into `handlers/validation.ts` and introducing method-specific keyring request structs (via `BtcMethod` literals) plus a shared `WalletAccountStruct`.
> 
> **Updates request shapes** so Bitcoin capability calls now validate a required `params.account.address` field for actions like `SignPsbt`, `FillPsbt`, `ComputeFee`, `BroadcastPsbt`, `SendTransfer`, `GetUtxo`, and `SignMessage`, with unit/integration tests adjusted accordingly. Also adds `NetworkStruct` in `caip.ts` and bumps the snap `manifest` bundle `shasum`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3d8f385c39a7783e8ce44fe9b1d26298dec4ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->