### PR TITLE
feat: add resolveAccountAddress method to KeyringHandler for dApp connectivity routing

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `resolveAccountAddress` method to KeyringHandler for dApp connectivity ([#590](https://github.com/MetaMask/snap-bitcoin-wallet/pull/590))
+
 ## [1.10.0]
 
 ### Changed

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add `resolveAccountAddress` method to KeyringHandler for dApp connectivity ([#590](https://github.com/MetaMask/snap-bitcoin-wallet/pull/590))
+
 ## [1.10.1]
 
 ### Fixed

--- a/packages/snap/integration-test/keyring-request.test.ts
+++ b/packages/snap/integration-test/keyring-request.test.ts
@@ -167,6 +167,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.GetUtxo,
             params: {
+              account: { address: account.address },
               outpoint: utxos[0]?.outpoint,
             },
           },
@@ -221,6 +222,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
               options: {
@@ -253,6 +255,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
               options: {
@@ -285,6 +288,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
               options: {
@@ -317,6 +321,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: 'notAPsbt',
               options: {
                 fill: true,
@@ -350,6 +355,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
             },
           },
@@ -382,6 +388,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.FillPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
             },
@@ -409,6 +416,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.FillPsbt,
             params: {
+              account: { address: account.address },
               psbt: 'notAPsbt',
             },
           },
@@ -444,6 +452,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.ComputeFee,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
             },
@@ -471,6 +480,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.ComputeFee,
             params: {
+              account: { address: account.address },
               psbt: 'notAPsbt',
             },
           },
@@ -507,6 +517,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignPsbt,
             params: {
+              account: { address: account.address },
               psbt: TEMPLATE_PSBT,
               feeRate: 3,
               options: {
@@ -533,6 +544,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.BroadcastPsbt,
             params: {
+              account: { address: account.address },
               psbt: result.psbt,
             },
           },
@@ -559,6 +571,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.BroadcastPsbt,
             params: {
+              account: { address: account.address },
               psbt: 'notAPsbt',
             },
           },
@@ -590,6 +603,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SendTransfer,
             params: {
+              account: { address: account.address },
               recipients: [
                 {
                   address: 'bcrt1qstku2y3pfh9av50lxj55arm8r5gj8tf2yv5nxz',
@@ -626,6 +640,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SendTransfer,
             params: {
+              account: { address: account.address },
               recipients: [{ address: 'notAnAddress', amount: '1000' }],
             },
           },
@@ -654,6 +669,7 @@ describe('KeyringRequestHandler', () => {
           request: {
             method: AccountCapability.SignMessage,
             params: {
+              account: { address: account.address },
               message: 'Hello, world!',
             },
           },

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "Ph0Ibbk8XLQfwi4HRKZx4SQ3itVjUHsMVQG/+/HIHbE=",
+    "shasum": "hxXtM5RCPhE5QGJSQI1yC/lA7g/SkFEealL9uGXtukA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "o9ZJmt7WEmIOXnmPlqmqRbGWztcCkDTKkW2VaBza56E=",
+    "shasum": "Ph0Ibbk8XLQfwi4HRKZx4SQ3itVjUHsMVQG/+/HIHbE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "hxXtM5RCPhE5QGJSQI1yC/lA7g/SkFEealL9uGXtukA=",
+    "shasum": "qdexQ1itu3G1EGrC7+GT2HFuNr++VxwFe9zLfHVPiKU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/handlers/KeyringHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringHandler.test.ts
@@ -940,6 +940,29 @@ describe('KeyringHandler', () => {
       expect(result).toBeNull();
     });
 
+    it('returns null when scope validation fails', async () => {
+      const request = {
+        id: '1',
+        jsonrpc: '2.0' as const,
+        method: BtcMethod.SignPsbt,
+        params: {
+          account: { address: 'test123' },
+          psbt: 'psbt',
+        },
+      };
+
+      jest.mocked(assert).mockImplementationOnce(() => {
+        throw new Error('Invalid scope');
+      });
+
+      const result = await handler.resolveAccountAddress(
+        'invalid-scope' as never,
+        request,
+      );
+
+      expect(result).toBeNull();
+    });
+
     it('returns null when request validation fails', async () => {
       const invalidRequest = {
         id: '1',
@@ -952,9 +975,13 @@ describe('KeyringHandler', () => {
         .spyOn(handler, 'listAccounts')
         .mockResolvedValue([mockKeyringAccount1, mockKeyringAccount2]);
 
-      jest.mocked(assert).mockImplementationOnce(() => {
-        throw new Error('Invalid request');
-      });
+      // First assert (scope) passes, second assert (request struct) throws
+      jest
+        .mocked(assert)
+        .mockImplementationOnce(() => undefined)
+        .mockImplementationOnce(() => {
+          throw new Error('Invalid request');
+        });
 
       const result = await handler.resolveAccountAddress(
         BtcScope.Regtest,

--- a/packages/snap/src/handlers/KeyringHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringHandler.test.ts
@@ -14,8 +14,9 @@ import type {
   KeyringResponse,
   Transaction as KeyringTransaction,
   KeyringRequest,
+  KeyringAccount,
 } from '@metamask/keyring-api';
-import { BtcAccountType, BtcScope } from '@metamask/keyring-api';
+import { BtcAccountType, BtcMethod, BtcScope } from '@metamask/keyring-api';
 import { mock } from 'jest-mock-extended';
 import { assert } from 'superstruct';
 
@@ -842,6 +843,125 @@ describe('KeyringHandler', () => {
 
       expect(mockKeyringRequest.route).toHaveBeenCalledWith(mockRequest);
       expect(result).toStrictEqual(expectedResponse);
+    });
+  });
+
+  describe('resolveAccountAddress', () => {
+    const mockKeyringAccount1 = mock<KeyringAccount>({
+      id: 'account-1',
+      address: 'test123',
+      scopes: [BtcScope.Regtest],
+    });
+    const mockKeyringAccount2 = mock<KeyringAccount>({
+      id: 'account-2',
+      address: 'test456',
+      scopes: [BtcScope.Regtest],
+    });
+
+    beforeEach(() => {
+      mockAccounts.list.mockResolvedValue([mockAccount]);
+    });
+
+    it('resolves account address successfully', async () => {
+      const request = {
+        id: '1',
+        jsonrpc: '2.0' as const,
+        method: BtcMethod.SignPsbt,
+        params: {
+          account: { address: 'test123' },
+          psbt: 'psbt',
+        },
+      };
+
+      jest
+        .spyOn(handler, 'listAccounts')
+        .mockResolvedValueOnce([mockKeyringAccount1, mockKeyringAccount2]);
+
+      const result = await handler.resolveAccountAddress(
+        BtcScope.Regtest,
+        request,
+      );
+
+      expect(handler.listAccounts).toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        address: `${BtcScope.Regtest}:test123`,
+      });
+    });
+
+    it('returns null when account address not found', async () => {
+      const request = {
+        id: '1',
+        jsonrpc: '2.0' as const,
+        method: BtcMethod.SignPsbt,
+        params: {
+          account: { address: 'notfound' },
+          psbt: 'psbt',
+        },
+      };
+
+      jest
+        .spyOn(handler, 'listAccounts')
+        .mockResolvedValue([mockKeyringAccount1, mockKeyringAccount2]);
+
+      const result = await handler.resolveAccountAddress(
+        BtcScope.Regtest,
+        request,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when no accounts match the scope', async () => {
+      const request = {
+        id: '1',
+        jsonrpc: '2.0' as const,
+        method: BtcMethod.SignPsbt,
+        params: {
+          account: { address: 'test123' },
+          psbt: 'psbt',
+        },
+      };
+
+      const accountWithDifferentScope = mock<KeyringAccount>({
+        id: 'account-3',
+        address: 'test123',
+        scopes: [BtcScope.Mainnet],
+      });
+
+      jest
+        .spyOn(handler, 'listAccounts')
+        .mockResolvedValue([accountWithDifferentScope]);
+
+      const result = await handler.resolveAccountAddress(
+        BtcScope.Regtest,
+        request,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when request validation fails', async () => {
+      const invalidRequest = {
+        id: '1',
+        jsonrpc: '2.0' as const,
+        method: 'invalid',
+        params: {},
+      };
+
+      jest
+        .spyOn(handler, 'listAccounts')
+        .mockResolvedValue([mockKeyringAccount1, mockKeyringAccount2]);
+
+      jest.mocked(assert).mockImplementationOnce(() => {
+        throw new Error('Invalid request');
+      });
+
+      const result = await handler.resolveAccountAddress(
+        BtcScope.Regtest,
+        invalidRequest,
+      );
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/snap/src/handlers/KeyringHandler.ts
+++ b/packages/snap/src/handlers/KeyringHandler.ts
@@ -1,6 +1,7 @@
 import type { AddressType } from '@metamask/bitcoindevkit';
 import {
   BtcAccountType,
+  BtcMethod,
   BtcScope,
   CreateAccountRequestStruct,
   DeleteAccountRequestStruct,
@@ -13,6 +14,7 @@ import {
   ListAccountsRequestStruct,
   ListAccountTransactionsRequestStruct,
   MetaMaskOptionsStruct,
+  ResolveAccountAddressRequestStruct,
   SetSelectedAccountsRequestStruct,
   SubmitRequestRequestStruct,
 } from '@metamask/keyring-api';
@@ -29,8 +31,9 @@ import type {
   MetaMaskOptions,
   DiscoveredAccount,
   KeyringRequest,
+  ResolvedAccountAddress,
 } from '@metamask/keyring-api';
-import type { Json, JsonRpcRequest } from '@metamask/snaps-sdk';
+import type { CaipChainId, Json, JsonRpcRequest } from '@metamask/snaps-sdk';
 import {
   assert,
   boolean,
@@ -54,6 +57,7 @@ import {
   caipToAddressType,
   scopeToNetwork,
   networkToScope,
+  NetworkStruct,
 } from './caip';
 import { CronMethod } from './CronHandler';
 import type { KeyringRequestHandler } from './KeyringRequestHandler';
@@ -62,7 +66,7 @@ import {
   mapToKeyringAccount,
   mapToTransaction,
 } from './mappings';
-import { validateSelectedAccounts } from './validation';
+import { BtcWalletRequestStruct, validateSelectedAccounts } from './validation';
 import type { AccountUseCases } from '../use-cases/AccountUseCases';
 import { runSnapActionSafely } from '../utils/snapHelpers';
 
@@ -159,6 +163,13 @@ export class KeyringHandler implements Keyring {
         assert(request, SetSelectedAccountsRequestStruct);
         await this.setSelectedAccounts(request.params.accounts);
         return null;
+      }
+      case `${KeyringRpcMethod.ResolveAccountAddress}`: {
+        assert(request, ResolveAccountAddressRequestStruct);
+        return this.resolveAccountAddress(
+          request.params.scope,
+          request.params.request,
+        );
       }
 
       default: {
@@ -384,6 +395,73 @@ export class KeyringHandler implements Keyring {
       method: CronMethod.SyncSelectedAccounts,
       params: { accountIds: accounts },
     });
+  }
+
+  /**
+   * Resolves the address of an account from a signing request.
+   *
+   * This is required by the routing system of MetaMask to dispatch
+   * incoming non-EVM dapp signing requests.
+   *
+   * @param scope - Request's scope (CAIP-2).
+   * @param request - Signing request object.
+   * @returns A Promise that resolves to the account address that must
+   * be used to process this signing request, or null if none candidates
+   * could be found.
+   */
+  async resolveAccountAddress(
+    scope: CaipChainId,
+    request: JsonRpcRequest,
+  ): Promise<ResolvedAccountAddress | null> {
+    try {
+      assert(scope, NetworkStruct);
+      const { method, params } = request;
+
+      const requestWithoutCommonHeader = { method, params };
+      assert(requestWithoutCommonHeader, BtcWalletRequestStruct);
+
+      const allAccounts = await this.listAccounts();
+
+      const accountsWithThisScope = allAccounts.filter((account) =>
+        account.scopes.includes(scope),
+      );
+
+      if (accountsWithThisScope.length === 0) {
+        throw new Error('No accounts with this scope');
+      }
+
+      let addressToValidate: string;
+
+      switch (requestWithoutCommonHeader.method) {
+        case BtcMethod.BroadcastPsbt:
+        case BtcMethod.FillPsbt:
+        case BtcMethod.ComputeFee:
+        case BtcMethod.GetUtxo:
+        case BtcMethod.SendTransfer:
+        case BtcMethod.SignMessage:
+        case BtcMethod.SignPsbt: {
+          const { account } = requestWithoutCommonHeader.params;
+          addressToValidate = account.address;
+          break;
+        }
+        default: {
+          throw new Error('Unsupported method');
+        }
+      }
+
+      const foundAccount = accountsWithThisScope.find(
+        (account) => account.address === addressToValidate,
+      );
+
+      if (!foundAccount) {
+        throw new Error('Account not found');
+      }
+
+      return { address: `${scope}:${addressToValidate}` };
+    } catch (error: unknown) {
+      this.#logger.error({ error }, 'Error resolving account address');
+      return null;
+    }
   }
 
   #extractAddressType(path: string): AddressType {

--- a/packages/snap/src/handlers/KeyringHandler.ts
+++ b/packages/snap/src/handlers/KeyringHandler.ts
@@ -1,7 +1,6 @@
 import type { AddressType } from '@metamask/bitcoindevkit';
 import {
   BtcAccountType,
-  BtcMethod,
   BtcScope,
   CreateAccountRequestStruct,
   DeleteAccountRequestStruct,
@@ -430,24 +429,8 @@ export class KeyringHandler implements Keyring {
         throw new Error('No accounts with this scope');
       }
 
-      let addressToValidate: string;
-
-      switch (requestWithoutCommonHeader.method) {
-        case BtcMethod.BroadcastPsbt:
-        case BtcMethod.FillPsbt:
-        case BtcMethod.ComputeFee:
-        case BtcMethod.GetUtxo:
-        case BtcMethod.SendTransfer:
-        case BtcMethod.SignMessage:
-        case BtcMethod.SignPsbt: {
-          const { account } = requestWithoutCommonHeader.params;
-          addressToValidate = account.address;
-          break;
-        }
-        default: {
-          throw new Error('Unsupported method');
-        }
-      }
+      const { address: addressToValidate } =
+        requestWithoutCommonHeader.params.account;
 
       const foundAccount = accountsWithThisScope.find(
         (account) => account.address === addressToValidate,

--- a/packages/snap/src/handlers/KeyringRequestHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringRequestHandler.test.ts
@@ -4,20 +4,26 @@ import { mock } from 'jest-mock-extended';
 import { assert } from 'superstruct';
 
 import type { AccountUseCases } from '../use-cases';
+import { KeyringRequestHandler } from './KeyringRequestHandler';
 import {
   BroadcastPsbtRequest,
   ComputeFeeRequest,
   FillPsbtRequest,
   GetUtxoRequest,
-  KeyringRequestHandler,
   SendTransferRequest,
   SignPsbtRequest,
-} from './KeyringRequestHandler';
+} from './validation';
 import type { BitcoinAccount } from '../entities';
 import { AccountCapability } from '../entities';
 import type { Utxo } from './mappings';
 import { mapToUtxo } from './mappings';
 import { parsePsbt } from './parsers';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+jest.mock('@metamask/bitcoindevkit', () => ({
+  Address: { from_string: jest.fn() },
+  Amount: { from_btc: jest.fn() },
+}));
 
 jest.mock('superstruct', () => ({
   ...jest.requireActual('superstruct'),
@@ -35,6 +41,11 @@ jest.mock('./mappings', () => ({
 describe('KeyringRequestHandler', () => {
   const mockAccountsUseCases = mock<AccountUseCases>();
   const origin = 'metamask';
+
+  const ACCOUNT_ADDRESS = 'test-account-address';
+  const accountParam = {
+    account: { address: ACCOUNT_ADDRESS },
+  };
 
   const handler = new KeyringRequestHandler(mockAccountsUseCases);
 
@@ -65,6 +76,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.SignPsbt,
         params: {
+          ...accountParam,
           psbt: 'psbtBase64',
           feeRate: 3,
           options: mockOptions,
@@ -109,7 +121,10 @@ describe('KeyringRequestHandler', () => {
       await expect(
         handler.route({
           ...mockRequest,
-          request: { ...mockRequest.request, params: { psbt: 'invalidPsbt' } },
+          request: {
+            ...mockRequest.request,
+            params: { ...accountParam, psbt: 'invalidPsbt' },
+          },
         }),
       ).rejects.toThrow(error);
 
@@ -131,6 +146,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.ComputeFee,
         params: {
+          ...accountParam,
           psbt: 'psbtBase64',
           feeRate: 3,
         },
@@ -141,7 +157,6 @@ describe('KeyringRequestHandler', () => {
     it('executes computeFee', async () => {
       mockAccountsUseCases.computeFee.mockResolvedValue(
         mock<Amount>({
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           to_sat: () => BigInt(1000),
         }),
       );
@@ -172,7 +187,10 @@ describe('KeyringRequestHandler', () => {
       await expect(
         handler.route({
           ...mockRequest,
-          request: { ...mockRequest.request, params: { psbt: 'invalidPsbt' } },
+          request: {
+            ...mockRequest.request,
+            params: { ...accountParam, psbt: 'invalidPsbt' },
+          },
         }),
       ).rejects.toThrow(error);
 
@@ -194,6 +212,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.FillPsbt,
         params: {
+          ...accountParam,
           psbt: 'psbtBase64',
           feeRate: 3,
         },
@@ -233,7 +252,10 @@ describe('KeyringRequestHandler', () => {
       await expect(
         handler.route({
           ...mockRequest,
-          request: { ...mockRequest.request, params: { psbt: 'invalidPsbt' } },
+          request: {
+            ...mockRequest.request,
+            params: { ...accountParam, psbt: 'invalidPsbt' },
+          },
         }),
       ).rejects.toThrow(error);
 
@@ -256,6 +278,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.BroadcastPsbt,
         params: {
+          ...accountParam,
           psbt: 'psbtBase64',
           feeRate: 3,
         },
@@ -295,7 +318,10 @@ describe('KeyringRequestHandler', () => {
       await expect(
         handler.route({
           ...mockRequest,
-          request: { ...mockRequest.request, params: { psbt: 'invalidPsbt' } },
+          request: {
+            ...mockRequest.request,
+            params: { ...accountParam, psbt: 'invalidPsbt' },
+          },
         }),
       ).rejects.toThrow(error);
 
@@ -324,6 +350,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.SendTransfer,
         params: {
+          ...accountParam,
           recipients,
           feeRate: 3,
         },
@@ -376,6 +403,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.GetUtxo,
         params: {
+          ...accountParam,
           outpoint: 'mytxid:0',
         },
       },
@@ -470,6 +498,7 @@ describe('KeyringRequestHandler', () => {
       request: {
         method: AccountCapability.SignMessage,
         params: {
+          ...accountParam,
           message: 'message',
         },
       },

--- a/packages/snap/src/handlers/KeyringRequestHandler.ts
+++ b/packages/snap/src/handlers/KeyringRequestHandler.ts
@@ -1,14 +1,6 @@
 import type { KeyringRequest, KeyringResponse } from '@metamask/keyring-api';
 import type { Json } from '@metamask/snaps-sdk';
-import {
-  array,
-  assert,
-  boolean,
-  number,
-  object,
-  optional,
-  string,
-} from 'superstruct';
+import { assert } from 'superstruct';
 
 import {
   AccountCapability,
@@ -17,66 +9,34 @@ import {
 } from '../entities';
 import { mapToUtxo } from './mappings';
 import { parsePsbt } from './parsers';
+import {
+  BroadcastPsbtRequest,
+  ComputeFeeRequest,
+  FillPsbtRequest,
+  GetUtxoRequest,
+  SendTransferRequest,
+  SignMessageRequest,
+  SignPsbtRequest,
+} from './validation';
 import type { AccountUseCases } from '../use-cases/AccountUseCases';
-
-export const SignPsbtRequest = object({
-  psbt: string(),
-  feeRate: optional(number()),
-  options: object({
-    fill: boolean(),
-    broadcast: boolean(),
-  }),
-});
 
 export type SignPsbtResponse = {
   psbt: string;
   txid: string | null;
 };
 
-export const ComputeFeeRequest = object({
-  psbt: string(),
-  feeRate: optional(number()),
-});
-
 export type ComputeFeeResponse = {
   // Fee in satoshis
   fee: string;
 };
 
-export const BroadcastPsbtRequest = object({
-  psbt: string(),
-});
-
 export type BroadcastPsbtResponse = {
   txid: string;
 };
 
-export const FillPsbtRequest = object({
-  psbt: string(),
-  feeRate: optional(number()),
-});
-
 export type FillPsbtResponse = {
   psbt: string;
 };
-
-export const SendTransferRequest = object({
-  recipients: array(
-    object({
-      address: string(),
-      amount: string(),
-    }),
-  ),
-  feeRate: optional(number()),
-});
-
-export const GetUtxoRequest = object({
-  outpoint: string(),
-});
-
-export const SignMessageRequest = object({
-  message: string(),
-});
 
 export type SignMessageResponse = {
   signature: string;

--- a/packages/snap/src/handlers/caip.ts
+++ b/packages/snap/src/handlers/caip.ts
@@ -1,5 +1,6 @@
 import type { AddressType, Network } from '@metamask/bitcoindevkit';
 import { BtcAccountType, BtcScope } from '@metamask/keyring-api';
+import { enums } from 'superstruct';
 
 const reverseMapping = <
   From extends string | number | symbol,
@@ -36,6 +37,8 @@ export enum Caip19Asset {
   Signet = 'bip122:00000008819873e925422c1ff0f99f7c/slip44:0',
   Regtest = 'bip122:regtest/slip44:0',
 }
+
+export const NetworkStruct = enums(Object.values(BtcScope));
 
 export const networkToCaip19: Record<Network, Caip19Asset> = {
   bitcoin: Caip19Asset.Bitcoin,

--- a/packages/snap/src/handlers/validation.test.ts
+++ b/packages/snap/src/handlers/validation.test.ts
@@ -1,4 +1,12 @@
-import { parseRewardsMessage } from './validation';
+import type { AddressType } from '@metamask/bitcoindevkit';
+import { mock } from 'jest-mock-extended';
+
+import type { BitcoinAccount } from '../entities';
+import {
+  parseRewardsMessage,
+  validateDustLimit,
+  validateSelectedAccounts,
+} from './validation';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 jest.mock('@metamask/bitcoindevkit', () => ({
@@ -11,6 +19,53 @@ jest.mock('@metamask/bitcoindevkit', () => ({
 }));
 
 describe('validation', () => {
+  describe('validateDustLimit', () => {
+    const makeAccount = (addressType: AddressType) =>
+      mock<BitcoinAccount>({ addressType });
+
+    it.each<{ type: AddressType; dust: bigint }>([
+      { type: 'p2pkh', dust: 546n },
+      { type: 'p2sh', dust: 540n },
+      { type: 'p2wsh', dust: 330n },
+      { type: 'p2tr', dust: 330n },
+      { type: 'p2wpkh', dust: 294n },
+    ])(
+      'returns valid for amount above dust limit for $type',
+      ({ type, dust }) => {
+        const amountBtc = (Number(dust) / 1e8 + 0.00000001).toFixed(8);
+        const mockFromBtc = { to_sat: () => dust + 1n };
+        const { Amount } = jest.requireMock('@metamask/bitcoindevkit');
+        Amount.from_btc.mockReturnValue(mockFromBtc);
+
+        const result = validateDustLimit(amountBtc, makeAccount(type));
+        expect(result.valid).toBe(true);
+      },
+    );
+
+    it('returns invalid for amount below dust limit', () => {
+      const mockFromBtc = { to_sat: () => 100n };
+      const { Amount } = jest.requireMock('@metamask/bitcoindevkit');
+      Amount.from_btc.mockReturnValue(mockFromBtc);
+
+      const result = validateDustLimit('0.000001', makeAccount('p2pkh'));
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('validateSelectedAccounts', () => {
+    it('does not throw when all account IDs exist', () => {
+      expect(() =>
+        validateSelectedAccounts(new Set(['a', 'b']), ['a', 'b', 'c']),
+      ).not.toThrow();
+    });
+
+    it('throws when an account ID does not exist', () => {
+      expect(() =>
+        validateSelectedAccounts(new Set(['a', 'x']), ['a', 'b']),
+      ).toThrow('Account IDs were not part of existing accounts.');
+    });
+  });
+
   describe('parseRewardsMessage', () => {
     const validBitcoinMainnetAddress =
       'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';

--- a/packages/snap/src/handlers/validation.ts
+++ b/packages/snap/src/handlers/validation.ts
@@ -92,7 +92,6 @@ export const NO_ERRORS_RESPONSE: ValidationResponse = {
   errors: [],
 };
 
-
 /**
  * Wallet account struct for Bitcoin requests.
  */

--- a/packages/snap/src/handlers/validation.ts
+++ b/packages/snap/src/handlers/validation.ts
@@ -199,8 +199,6 @@ export const BtcWalletRequestStruct = union([
   SignMessageKeyringRequestStruct,
 ]);
 
-export type BtcWalletRequest = Infer<typeof BtcWalletRequestStruct>;
-
 /**
  * Validates that an amount is a positive number
  *

--- a/packages/snap/src/handlers/validation.ts
+++ b/packages/snap/src/handlers/validation.ts
@@ -1,5 +1,6 @@
 import type { Network, AddressType } from '@metamask/bitcoindevkit';
 import { Address, Amount } from '@metamask/bitcoindevkit';
+import { BtcMethod } from '@metamask/keyring-api';
 import { CaipAssetTypeStruct } from '@metamask/utils';
 import type { Infer } from 'superstruct';
 import {
@@ -7,10 +8,14 @@ import {
   array,
   boolean,
   enums,
+  literal,
+  number,
   object,
+  optional,
   string,
   nonempty,
   refine,
+  union,
   is,
 } from 'superstruct';
 
@@ -86,6 +91,116 @@ export const NO_ERRORS_RESPONSE: ValidationResponse = {
   valid: true,
   errors: [],
 };
+
+
+/**
+ * Wallet account struct for Bitcoin requests.
+ */
+const WalletAccountStruct = object({
+  address: string(),
+});
+
+export const SignPsbtRequest = object({
+  account: WalletAccountStruct,
+  psbt: string(),
+  feeRate: optional(number()),
+  options: object({
+    fill: boolean(),
+    broadcast: boolean(),
+  }),
+});
+
+export const ComputeFeeRequest = object({
+  account: WalletAccountStruct,
+  psbt: string(),
+  feeRate: optional(number()),
+});
+
+export const BroadcastPsbtRequest = object({
+  account: WalletAccountStruct,
+  psbt: string(),
+});
+
+export const FillPsbtRequest = object({
+  account: WalletAccountStruct,
+  psbt: string(),
+  feeRate: optional(number()),
+});
+
+export const SendTransferRequest = object({
+  account: WalletAccountStruct,
+  recipients: array(
+    object({
+      address: string(),
+      amount: string(),
+    }),
+  ),
+  feeRate: optional(number()),
+});
+
+export const GetUtxoRequest = object({
+  account: WalletAccountStruct,
+  outpoint: string(),
+});
+
+export const SignMessageRequest = object({
+  account: WalletAccountStruct,
+  message: string(),
+});
+
+/**
+ * Validates that a JsonRpcRequest is a valid Bitcoin request.
+ *
+ * TODO: update btc-methods.md to include all the new methods
+ *
+ * @see https://github.com/MetaMask/accounts/blob/main/packages/keyring-api/docs/btc-methods.md
+ */
+export const SignPsbtKeyringRequestStruct = object({
+  method: literal(BtcMethod.SignPsbt),
+  params: SignPsbtRequest,
+});
+
+export const FillPsbtKeyringRequestStruct = object({
+  method: literal(BtcMethod.FillPsbt),
+  params: FillPsbtRequest,
+});
+
+export const ComputeFeeKeyringRequestStruct = object({
+  method: literal(BtcMethod.ComputeFee),
+  params: ComputeFeeRequest,
+});
+
+export const BroadcastPsbtKeyringRequestStruct = object({
+  method: literal(BtcMethod.BroadcastPsbt),
+  params: BroadcastPsbtRequest,
+});
+
+export const SendTransferKeyringRequestStruct = object({
+  method: literal(BtcMethod.SendTransfer),
+  params: SendTransferRequest,
+});
+
+export const GetUtxoKeyringRequestStruct = object({
+  method: literal(BtcMethod.GetUtxo),
+  params: GetUtxoRequest,
+});
+
+export const SignMessageKeyringRequestStruct = object({
+  method: literal(BtcMethod.SignMessage),
+  params: SignMessageRequest,
+});
+
+export const BtcWalletRequestStruct = union([
+  SignPsbtKeyringRequestStruct,
+  FillPsbtKeyringRequestStruct,
+  ComputeFeeKeyringRequestStruct,
+  BroadcastPsbtKeyringRequestStruct,
+  SendTransferKeyringRequestStruct,
+  GetUtxoKeyringRequestStruct,
+  SignMessageKeyringRequestStruct,
+]);
+
+export type BtcWalletRequest = Infer<typeof BtcWalletRequestStruct>;
 
 /**
  * Validates that an amount is a positive number


### PR DESCRIPTION
## Explanation
This PR contributes to supporting the Bitcoin dApp connectivity.
It's adding the resolve account address Keyring method.

It is part from the initial PR [#564 feat: enable account address resolution to support dApps connectivity](https://github.com/MetaMask/snap-bitcoin-wallet/pull/564) to split the work into 3 smaller PRs:
[#589 refactor: move validation structs and add account field](https://github.com/MetaMask/snap-bitcoin-wallet/pull/589)
[#590 feat: add resolveAccountAddress method to KeyringHandler for dApp connectivity routing](https://github.com/MetaMask/snap-bitcoin-wallet/pull/590)
[#591 feat: add confirmation dialog before sendTransfer and before signing a PSBT from the keyring handler](https://github.com/MetaMask/snap-bitcoin-wallet/pull/591)

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Keyring RPC method used for dapp request routing and tightens request validation shapes (including a required `account.address` field), which could affect compatibility with existing callers if they don’t send the new params.
> 
> **Overview**
> Adds Keyring API support for `keyring_resolveAccountAddress` by implementing `KeyringHandler.resolveAccountAddress`, which validates the incoming Bitcoin request, filters accounts by `scope`, and returns a CAIP-10 style `scope:address` (or `null` on failure) to enable MetaMask dapp signing request routing.
> 
> Updates Bitcoin request validation by centralizing the Superstruct schemas in `validation.ts` (and reusing them from `KeyringRequestHandler`), requiring an explicit `params.account.address` across signing/PSBT/transfer/UTXO/message requests; tests and integration fixtures are adjusted accordingly. Changelog and snap manifest `shasum` are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e614c7b5c8baec0fb6ea91886a866b4b1253ba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->