### PR TITLE
refactor: replace hardcoded dust limits with BDK's is_dust()

### DIFF
--- a/packages/snap/src/handlers/validation.ts
+++ b/packages/snap/src/handlers/validation.ts
@@ -1,4 +1,4 @@
-import type { Network, AddressType } from '@metamask/bitcoindevkit';
+import type { Network } from '@metamask/bitcoindevkit';
 import { Address, Amount } from '@metamask/bitcoindevkit';
 import { CaipAssetTypeStruct } from '@metamask/utils';
 import type { Infer } from 'superstruct';
@@ -176,42 +176,22 @@ export function validateSelectedAccounts(
 }
 
 /**
- * Returns the dust limit (in satoshis) for a given address type.
- *
- * @param addressType - The account address type (script type).
- * @returns The minimum spendable amount in satoshis for this script type.
- */
-function getDustLimitSats(addressType: AddressType): bigint {
-  switch (addressType) {
-    case 'p2wpkh':
-      return 294n;
-    case 'p2pkh':
-      return 546n;
-    case 'p2sh':
-      return 540n;
-    case 'p2wsh':
-      return 330n;
-    case 'p2tr':
-      return 330n;
-    default:
-      return 546n;
-  }
-}
-
-/**
  * Validates that the amount is above the dust limit for the account's script type.
  *
+ * Uses BDK's `Amount.is_dust()` which computes the dust threshold from the actual
+ * script, matching Bitcoin Core's relay policy exactly. This replaces the previous
+ * hardcoded per-address-type dust limits.
+ *
  * @param amountInBtc - The amount to send, in BTC units.
- * @param account - The Bitcoin account providing address type and context.
+ * @param account - The Bitcoin account providing the public address and script.
  * @returns ValidationResponse indicating whether the amount meets dust requirements.
  */
 export function validateDustLimit(
   amountInBtc: string,
   account: BitcoinAccount,
 ): ValidationResponse {
-  const sats = Amount.from_btc(Number(amountInBtc)).to_sat();
-  const min = getDustLimitSats(account.addressType);
-  if (sats < min) {
+  const amount = Amount.from_btc(Number(amountInBtc));
+  if (amount.is_dust(account.publicAddress.script_pubkey)) {
     return { valid: false, errors: [{ code: SendErrorCodes.Invalid }] };
   }
   return NO_ERRORS_RESPONSE;


### PR DESCRIPTION
## Summary

Replace the hardcoded `getDustLimitSats` switch statement in `validation.ts` with BDK's `Amount.is_dust(script)` method, which computes dust thresholds from the actual script — matching Bitcoin Core's relay policy exactly.

## Before

```ts
function getDustLimitSats(addressType: AddressType): bigint {
  switch (addressType) {
    case 'p2wpkh': return 294n;
    case 'p2pkh':  return 546n;
    case 'p2sh':   return 540n;
    case 'p2wsh':  return 330n;
    case 'p2tr':   return 330n;
    default:       return 546n;
  }
}
```

## After

```ts
const amount = Amount.from_btc(Number(amountInBtc));
if (amount.is_dust(account.publicAddress.script_pubkey)) { ... }
```

## Benefits

- **Correct by construction** — delegates to BDK / bitcoin-core's dust relay logic
- **Future-proof** — automatically handles new script types without code changes
- **Less maintenance** — no hardcoded constants to keep in sync
- **Simpler** — removes ~25 lines, replaces with 2

## Dependency

This requires `@metamask/bitcoindevkit` to be built from [`bitcoindevkit/bdk-wasm`](https://github.com/bitcoindevkit/bdk-wasm) **v0.3.0+** (release PR: [bitcoindevkit/bdk-wasm#41](https://github.com/bitcoindevkit/bdk-wasm/pull/41)), which exposes:

- `Amount.is_dust(script)` — check if amount is below dust for a script
- `ScriptBuf.minimal_non_dust()` — get the minimum non-dust amount for a script
- `ScriptBuf.minimal_non_dust_custom(fee_rate)` — same with custom dust relay fee

These were added in [bitcoindevkit/bdk-wasm#13](https://github.com/bitcoindevkit/bdk-wasm/pull/13).

## Testing

Existing dust limit tests in `RpcHandler.test.ts` (lines 605-642) should continue to pass since the BDK computation produces the same thresholds (294 sats for p2wpkh) as the previously hardcoded values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes send-amount validation behavior by delegating dust checks to BDK’s `Amount.is_dust(script_pubkey)`, which could alter edge-case acceptance/rejection depending on the underlying BDK version and script type handling.
> 
> **Overview**
> `validateDustLimit` now uses BDK’s `Amount.is_dust(account.publicAddress.script_pubkey)` to enforce dust limits, removing the hardcoded per-`AddressType` dust threshold switch and the `AddressType` import.
> 
> This makes dust validation depend on the actual output script (matching Bitcoin Core relay policy) rather than a fixed table of constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a12eedfdb692c829a2ac5ee25774ce4bbe32906. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->