### PR TITLE
fix: include BDK cause in PSBT build error message

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Include BDK cause message in PSBT build error for better diagnostics ([#594](https://github.com/MetaMask/snap-bitcoin-wallet/pull/594))
+
 ## [1.10.0]
 
 ### Changed

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "iefJB+kNw+r6SHR7mNYsbqyX8A9H7Ru6dek888COXUg=",
+    "shasum": "9A7P9FuiCw0FWzEmUZLeRp7htng0eXeyl07ZKXsVhcU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "o9ZJmt7WEmIOXnmPlqmqRbGWztcCkDTKkW2VaBza56E=",
+    "shasum": "DXkPOY35iJdBi51Pa16cNeoWaue9vIc1NjIYlmqTRGc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "9A7P9FuiCw0FWzEmUZLeRp7htng0eXeyl07ZKXsVhcU=",
+    "shasum": "M7LJk6fzMpw9tjV4ytZEJpcNaMfY6t4RUQacQCqfGz8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "DXkPOY35iJdBi51Pa16cNeoWaue9vIc1NjIYlmqTRGc=",
+    "shasum": "iefJB+kNw+r6SHR7mNYsbqyX8A9H7Ru6dek888COXUg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/infra/BdkTxBuilderAdapter.ts
+++ b/packages/snap/src/infra/BdkTxBuilderAdapter.ts
@@ -103,6 +103,10 @@ export class BdkTxBuilderAdapter implements TransactionBuilder {
   }
 
   finish(): Psbt {
-    return this.#builder.finish();
+    try {
+      return this.#builder.finish();
+    } catch (error) {
+      throw new Error((error as CodifiedError).message);
+    }
   }
 }

--- a/packages/snap/src/infra/BdkTxBuilderAdapter.ts
+++ b/packages/snap/src/infra/BdkTxBuilderAdapter.ts
@@ -103,10 +103,6 @@ export class BdkTxBuilderAdapter implements TransactionBuilder {
   }
 
   finish(): Psbt {
-    try {
-      return this.#builder.finish();
-    } catch (error) {
-      throw new Error((error as CodifiedError).message);
-    }
+    return this.#builder.finish();
   }
 }

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -1214,7 +1214,7 @@ describe('AccountUseCases', () => {
         useCases.fillPsbt('account-id', mockTemplatePsbt),
       ).rejects.toThrow(
         new ValidationError(
-          'Failed to build PSBT from template',
+          'Failed to build PSBT from template: builder error',
           {
             id: 'account-id',
             templatePsbt: 'base64Psbt',

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -1225,6 +1225,17 @@ describe('AccountUseCases', () => {
       );
     });
 
+    it('includes non-Error cause in ValidationError message', async () => {
+      const bdkError = { message: 'InsufficientFunds', code: 11 };
+      mockTxBuilder.finish.mockImplementation(() => {
+        throw bdkError;
+      });
+
+      await expect(
+        useCases.fillPsbt('account-id', mockTemplatePsbt),
+      ).rejects.toThrow('Failed to build PSBT from template: InsufficientFunds');
+    });
+
     it('preserves all outputs from bridge PSBT template including change', async () => {
       // Simulate a bridge transaction with 3 outputs:
       // Output 0: Bridge deposit

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -1238,6 +1238,17 @@ describe('AccountUseCases', () => {
       );
     });
 
+    it('uses unknown cause when error has no message', async () => {
+      mockTxBuilder.finish.mockImplementation(() => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw 42;
+      });
+
+      await expect(
+        useCases.fillPsbt('account-id', mockTemplatePsbt),
+      ).rejects.toThrow('Failed to build PSBT from template: unknown cause');
+    });
+
     it('preserves all outputs from bridge PSBT template including change', async () => {
       // Simulate a bridge transaction with 3 outputs:
       // Output 0: Bridge deposit

--- a/packages/snap/src/use-cases/AccountUseCases.test.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.test.ts
@@ -1226,14 +1226,16 @@ describe('AccountUseCases', () => {
     });
 
     it('includes non-Error cause in ValidationError message', async () => {
-      const bdkError = { message: 'InsufficientFunds', code: 11 };
       mockTxBuilder.finish.mockImplementation(() => {
-        throw bdkError;
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw { message: 'InsufficientFunds', code: 11 };
       });
 
       await expect(
         useCases.fillPsbt('account-id', mockTemplatePsbt),
-      ).rejects.toThrow('Failed to build PSBT from template: InsufficientFunds');
+      ).rejects.toThrow(
+        'Failed to build PSBT from template: InsufficientFunds',
+      );
     });
 
     it('preserves all outputs from bridge PSBT template including change', async () => {

--- a/packages/snap/src/use-cases/AccountUseCases.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.ts
@@ -617,7 +617,9 @@ export class AccountUseCases {
       return builtPsbt;
     } catch (error) {
       const causeMessage =
-        error instanceof Error ? error.message : String(error);
+        error instanceof Error
+          ? error.message
+          : (error as { message?: string }).message ?? String(error);
       throw new ValidationError(
         `Failed to build PSBT from template: ${causeMessage}`,
         {

--- a/packages/snap/src/use-cases/AccountUseCases.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.ts
@@ -619,7 +619,7 @@ export class AccountUseCases {
       const causeMessage =
         error instanceof Error
           ? error.message
-          : (error as { message?: string }).message ?? String(error);
+          : ((error as { message?: string }).message ?? String(error));
       throw new ValidationError(
         `Failed to build PSBT from template: ${causeMessage}`,
         {

--- a/packages/snap/src/use-cases/AccountUseCases.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.ts
@@ -616,8 +616,10 @@ export class AccountUseCases {
 
       return builtPsbt;
     } catch (error) {
+      const causeMessage =
+        error instanceof Error ? error.message : String(error);
       throw new ValidationError(
-        'Failed to build PSBT from template',
+        `Failed to build PSBT from template: ${causeMessage}`,
         {
           id: account.id,
           templatePsbt: templatePsbt.toString(),

--- a/packages/snap/src/use-cases/AccountUseCases.ts
+++ b/packages/snap/src/use-cases/AccountUseCases.ts
@@ -616,10 +616,7 @@ export class AccountUseCases {
 
       return builtPsbt;
     } catch (error) {
-      const causeMessage =
-        error instanceof Error
-          ? error.message
-          : ((error as { message?: string }).message ?? String(error));
+      const causeMessage = (error as Error)?.message ?? 'unknown cause';
       throw new ValidationError(
         `Failed to build PSBT from template: ${causeMessage}`,
         {


### PR DESCRIPTION
## Problem

The "Failed to build PSBT from template" error is one of the top errors in Unified SwapBridge (~7.5% of failures). The root cause from BDK (e.g. `InsufficientFunds`, `OutputBelowDustLimit`, `NoUtxosSelected`) is lost when crossing the snap JSON-RPC boundary because:

1. `HandlerMiddleware` re-throws as `InvalidParamsError` which doesn't accept a `cause` parameter ([line 71](https://github.com/MetaMask/snap-bitcoin-wallet/blob/main/packages/snap/src/handlers/HandlerMiddleware.ts#L71-L74))
2. `emitTrackingError` checks `error.cause instanceof Error` but BDK WASM errors are `CodifiedError` plain objects, not `Error` instances ([line 308](https://github.com/MetaMask/snap-bitcoin-wallet/blob/main/packages/snap/src/infra/SnapClientAdapter.ts#L308))

This makes it impossible to diagnose why the PSBT rebuild fails in Sentry or Mixpanel.

## Solution

Append the BDK cause message to the `ValidationError` message string so it survives serialization through the RPC boundary and appears in Sentry/Mixpanel. Handles both `Error` instances and BDK's `CodifiedError` plain objects.

After this change, errors will appear as:
```
Validation failed: Failed to build PSBT from template: InsufficientFunds
```
instead of:
```
Validation failed: Failed to build PSBT from template
```

## Test plan
- [x] Existing tests updated and passing
- [x] New test for non-Error (CodifiedError) cause extraction
- [ ] Verify in Sentry that new errors include the BDK cause message after deployment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error-message composition and accompanying unit tests, with no effect on PSBT construction logic. Main potential impact is on any consumers asserting exact error strings.
> 
> **Overview**
> **PSBT build failures now surface the underlying cause message.** When `AccountUseCases.#fillPsbt` fails to `finish()` a transaction, the thrown `ValidationError` message is updated from a generic "Failed to build PSBT from template" to include the caught error’s `.message` (or `unknown cause` when absent), ensuring the reason survives RPC serialization.
> 
> Tests are updated/added to cover `Error` causes, non-`Error` object causes, and missing-message causes, and the change is documented in the Unreleased changelog (with the snap `manifest` `shasum` updated for the new bundle).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0413df2b1f18e26a0a26259af6fdca908c1c429. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->