### PR TITLE
feat(keyring): enable P2TR taproot account creation

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enable P2TR (taproot) account creation alongside P2WPKH
+- Accept BIP-86 (purpose 86) derivation paths for taproot accounts
+- Include P2TR in account discovery
+
 ## [1.10.1]
 
 ### Fixed

--- a/packages/snap/src/handlers/KeyringHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringHandler.test.ts
@@ -197,11 +197,14 @@ describe('KeyringHandler', () => {
       expect(mockAccounts.create).toHaveBeenCalledWith(expectedCreateParams);
     });
 
-    it.each([{ purpose: Purpose.NativeSegwit, addressType: 'p2wpkh' }] as {
+    it.each([
+      { purpose: Purpose.NativeSegwit, addressType: 'p2wpkh' },
+      { purpose: Purpose.Taproot, addressType: 'p2tr' },
+    ] as {
       purpose: Purpose;
       addressType: AddressType;
     }[])(
-      'extracts P2WPKH address type from derivationPath: %s',
+      'extracts P2WPKH and P2TR address type from derivationPath: %s',
       async ({ purpose, addressType }) => {
         const options = {
           scope: BtcScope.Signet,
@@ -220,11 +223,10 @@ describe('KeyringHandler', () => {
       },
     );
 
-    // skip non-P2WPKH address types as they are not supported on v1
+    // skip non-P2WPKH/P2TR address types as they are not yet supported
     it.skip.each([
       { purpose: Purpose.Legacy, addressType: 'p2pkh' },
       { purpose: Purpose.Segwit, addressType: 'p2sh' },
-      { purpose: Purpose.Taproot, addressType: 'p2tr' },
       { purpose: Purpose.Multisig, addressType: 'p2wsh' },
     ] as { purpose: Purpose; addressType: AddressType }[])(
       'extracts address type from derivationPath: %s',
@@ -279,7 +281,7 @@ describe('KeyringHandler', () => {
       // The error comes from #extractAddressType which validates the derivation path first
       await expect(handler.createAccount(options)).rejects.toThrow(
         new FormatError(
-          'Only native segwit (BIP-84) derivation paths are supported',
+          'Only native segwit (BIP-84) and taproot (BIP-86) derivation paths are supported',
         ),
       );
     });
@@ -294,6 +296,42 @@ describe('KeyringHandler', () => {
         network: 'signet',
         index: 5,
         addressType: 'p2wpkh',
+        entropySource: 'm',
+        synchronize: false,
+      };
+
+      await handler.createAccount(options);
+      expect(mockAccounts.create).toHaveBeenCalledWith(expectedCreateParams);
+    });
+
+    it('succeeds when addressType and derivationPath both indicate P2TR', async () => {
+      const options = {
+        scope: BtcScope.Mainnet,
+        addressType: BtcAccountType.P2tr,
+        derivationPath: "m/86'/0'/0'", // BIP-86 taproot path
+      };
+      const expectedCreateParams: CreateAccountParams = {
+        network: 'bitcoin',
+        index: 0,
+        addressType: 'p2tr',
+        entropySource: 'm',
+        synchronize: false,
+      };
+
+      await handler.createAccount(options);
+      expect(mockAccounts.create).toHaveBeenCalledWith(expectedCreateParams);
+    });
+
+    it('succeeds when only P2TR addressType is provided', async () => {
+      const options = {
+        scope: BtcScope.Mainnet,
+        addressType: BtcAccountType.P2tr,
+        index: 3,
+      };
+      const expectedCreateParams: CreateAccountParams = {
+        network: 'bitcoin',
+        index: 3,
+        addressType: 'p2tr',
         entropySource: 'm',
         synchronize: false,
       };
@@ -395,8 +433,8 @@ describe('KeyringHandler', () => {
     const scopes = Object.values(BtcScope);
 
     it('creates, scans and returns accounts for every scope/addressType combination', async () => {
-      // only P2WPKH is now supported for v1
-      const addressTypes = [BtcAccountType.P2wpkh];
+      // P2WPKH and P2TR are supported
+      const addressTypes = [BtcAccountType.P2wpkh, BtcAccountType.P2tr];
       const totalCombinations = scopes.length * addressTypes.length;
 
       const expected: DiscoveredAccount[] = [];
@@ -442,11 +480,19 @@ describe('KeyringHandler', () => {
 
     it('returns mix of accounts with and without history, filtering correctly', async () => {
       // create mock accounts - some with history, some without
+      // Each scope produces two discover calls (P2WPKH + P2TR)
       const accountWithHistory1 = mock<BitcoinAccount>({
         addressType: 'p2wpkh',
         network: 'bitcoin',
         listTransactions: jest.fn().mockReturnValue([{}, {}]), // has 2 transactions
         derivationPath: ['m', "84'", "0'", "0'"],
+      });
+
+      const p2trNoHistory1 = mock<BitcoinAccount>({
+        addressType: 'p2tr',
+        network: 'bitcoin',
+        listTransactions: jest.fn().mockReturnValue([]),
+        derivationPath: ['m', "86'", "0'", "0'"],
       });
 
       const accountWithoutHistory = mock<BitcoinAccount>({
@@ -456,6 +502,13 @@ describe('KeyringHandler', () => {
         derivationPath: ['m', "84'", "1'", "0'"],
       });
 
+      const p2trNoHistory2 = mock<BitcoinAccount>({
+        addressType: 'p2tr',
+        network: 'testnet',
+        listTransactions: jest.fn().mockReturnValue([]),
+        derivationPath: ['m', "86'", "1'", "0'"],
+      });
+
       const accountWithHistory2 = mock<BitcoinAccount>({
         addressType: 'p2wpkh',
         network: 'signet',
@@ -463,10 +516,20 @@ describe('KeyringHandler', () => {
         derivationPath: ['m', "84'", "1'", "0'"],
       });
 
+      const p2trWithHistory = mock<BitcoinAccount>({
+        addressType: 'p2tr',
+        network: 'signet',
+        listTransactions: jest.fn().mockReturnValue([{}]), // has history
+        derivationPath: ['m', "86'", "1'", "0'"],
+      });
+
       mockAccounts.discover
         .mockResolvedValueOnce(accountWithHistory1)
+        .mockResolvedValueOnce(p2trNoHistory1)
         .mockResolvedValueOnce(accountWithoutHistory)
-        .mockResolvedValueOnce(accountWithHistory2);
+        .mockResolvedValueOnce(p2trNoHistory2)
+        .mockResolvedValueOnce(accountWithHistory2)
+        .mockResolvedValueOnce(p2trWithHistory);
 
       const discovered = await handler.discoverAccounts(
         [BtcScope.Mainnet, BtcScope.Testnet, BtcScope.Signet],
@@ -474,11 +537,12 @@ describe('KeyringHandler', () => {
         groupIndex,
       );
 
-      expect(mockAccounts.discover).toHaveBeenCalledTimes(3);
-      expect(discovered).toHaveLength(2);
+      expect(mockAccounts.discover).toHaveBeenCalledTimes(6);
+      expect(discovered).toHaveLength(3);
       expect(discovered).toStrictEqual([
         mapToDiscoveredAccount(accountWithHistory1),
         mapToDiscoveredAccount(accountWithHistory2),
+        mapToDiscoveredAccount(p2trWithHistory),
       ]);
     });
 

--- a/packages/snap/src/handlers/KeyringHandler.ts
+++ b/packages/snap/src/handlers/KeyringHandler.ts
@@ -214,10 +214,13 @@ export class KeyringHandler implements Keyring {
 
       let resolvedAddressType: AddressType;
       if (addressType) {
-        // only support P2WPKH addresses for v1
-        if (addressType !== BtcAccountType.P2wpkh) {
+        // Support P2WPKH and P2TR address types
+        if (
+          addressType !== BtcAccountType.P2wpkh &&
+          addressType !== BtcAccountType.P2tr
+        ) {
           throw new FormatError(
-            'Only native segwit (P2WPKH) addresses are supported',
+            'Only native segwit (P2WPKH) and taproot (P2TR) addresses are supported',
           );
         }
         resolvedAddressType = caipToAddressType[addressType];
@@ -233,10 +236,13 @@ export class KeyringHandler implements Keyring {
         resolvedAddressType = this.#extractAddressType(derivationPath);
       } else {
         resolvedAddressType = this.#defaultAddressType;
-        // validate default address type is P2WPKH just to be sure
-        if (resolvedAddressType !== 'p2wpkh') {
+        // validate default address type is a supported type
+        if (
+          resolvedAddressType !== 'p2wpkh' &&
+          resolvedAddressType !== 'p2tr'
+        ) {
           throw new FormatError(
-            'Only native segwit (P2WPKH) addresses are supported',
+            'Only native segwit (P2WPKH) and taproot (P2TR) addresses are supported',
           );
         }
       }
@@ -284,8 +290,8 @@ export class KeyringHandler implements Keyring {
   ): Promise<DiscoveredAccount[]> {
     const accounts = await Promise.all(
       scopes.flatMap((scope) =>
-        // only discover P2WPKH addresses
-        [BtcAccountType.P2wpkh].map(async (addressType) =>
+        // discover P2WPKH and P2TR addresses
+        [BtcAccountType.P2wpkh, BtcAccountType.P2tr].map(async (addressType) =>
           this.#accountsUseCases.discover({
             network: scopeToNetwork[scope],
             entropySource,
@@ -404,10 +410,13 @@ export class KeyringHandler implements Keyring {
       throw new FormatError(`Invalid BIP-purpose: ${purpose}`);
     }
 
-    // only support native segwit (BIP-84) derivation paths for now
-    if ((purpose as Purpose) !== Purpose.NativeSegwit) {
+    // support native segwit (BIP-84) and taproot (BIP-86) derivation paths
+    if (
+      (purpose as Purpose) !== Purpose.NativeSegwit &&
+      (purpose as Purpose) !== Purpose.Taproot
+    ) {
       throw new FormatError(
-        `Only native segwit (BIP-84) derivation paths are supported`,
+        `Only native segwit (BIP-84) and taproot (BIP-86) derivation paths are supported`,
       );
     }
 


### PR DESCRIPTION
## Explanation

The snap currently restricts account creation to P2WPKH only, enforced
by three guards in `KeyringHandler` documented as v1 restrictions. The
full P2TR pipeline already exists: `@metamask/bitcoindevkit` handles
taproot natively, `caipToAddressType` maps `P2tr → 'p2tr'`,
`Purpose.Taproot = 86` and `purposeToAddressType` are defined in
`entities/account.ts`, and the extension UI maps `P2tr` to 'Taproot'.
Only the whitelist checks block taproot.

This PR widens the whitelist to accept P2TR alongside P2WPKH:

- `createAccount`: accept `BtcAccountType.P2tr` in address type validation
- `#extractAddressType`: accept BIP-86 (purpose 86) derivation paths
- `discoverAccounts`: include P2TR in the address type discovery list

No new dependencies. No changes to BDK integration, CAIP mappings, or
account infrastructure. Existing P2WPKH behavior is unchanged.

## References

- Companion PR: MetaMask/bitcoin-wallet-standard#30
- [BIP-86: Key Derivation for Single Key P2TR Outputs](https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki)
- [BIP-341: Taproot (SegWit version 1 spending rules)](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands supported account types and derivation-path validation, and doubles discovery calls (P2WPKH + P2TR) which can impact account creation/discovery behavior across networks. While scoped to whitelisting/validation, it touches keyring account flows that affect wallet state and UX.
> 
> **Overview**
> Enables **Taproot (`P2TR`) accounts** alongside existing `P2WPKH` in `KeyringHandler`.
> 
> `createAccount` now accepts `BtcAccountType.P2tr`, validates defaults accordingly, and `#extractAddressType` permits BIP-86 (purpose `86`) derivation paths (updating related error messages). `discoverAccounts` is expanded to include `P2TR` in discovery, and tests/changelog are updated to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed91b3bc0c003369c0fc6336b13104dbaf6c35a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->