### PR TITLE
fix: update error reporting 

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Preserve original error message and class when wrapping unknown errors at the handler boundary ([#600](https://github.com/MetaMask/snap-bitcoin-wallet/pull/600))
-
 ### Changed
 
 - Show a confirmation dialog before signing a PSBT from KeyringHandler and sending a transfer ([#591](https://github.com/MetaMask/snap-bitcoin-wallet/pull/591))
 - Add `resolveAccountAddress` method to KeyringHandler for dApp connectivity ([#590](https://github.com/MetaMask/snap-bitcoin-wallet/pull/590))
+
+### Fixed
+
+- Preserve original error message and class when wrapping unknown errors at the handler boundary ([#600](https://github.com/MetaMask/snap-bitcoin-wallet/pull/600))
 
 ## [1.10.1]
 

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve original error message and class when wrapping unknown errors at the handler boundary ([#600](https://github.com/MetaMask/snap-bitcoin-wallet/pull/600))
+
 ## [1.10.1]
 
 ### Fixed

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.1",
+  "version": "1.10.0",
   "description": "Manage Bitcoin using MetaMask",
   "proposedName": "Bitcoin",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "PFNCTbRXfVgG6MYd4pGachmIHIIxcEOeM46SNJ89aFA=",
+    "shasum": "M7LJk6fzMpw9tjV4ytZEJpcNaMfY6t4RUQacQCqfGz8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Manage Bitcoin using MetaMask",
   "proposedName": "Bitcoin",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "M7LJk6fzMpw9tjV4ytZEJpcNaMfY6t4RUQacQCqfGz8=",
+    "shasum": "PFNCTbRXfVgG6MYd4pGachmIHIIxcEOeM46SNJ89aFA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/handlers/HandlerMiddleware.test.ts
+++ b/packages/snap/src/handlers/HandlerMiddleware.test.ts
@@ -40,14 +40,31 @@ describe('HandlerMiddleware', () => {
       expect(result).toBe('success');
     });
 
-    it('throws internal error if error is unexpected', async () => {
-      const mockFn = jest.fn().mockRejectedValue(new Error());
+    it('wraps an unexpected Error and preserves its message', async () => {
+      const error = new Error('boom');
+      const mockFn = jest.fn().mockRejectedValue(error);
 
-      await expect(middleware.handle(mockFn)).rejects.toThrow(
-        'Unexpected error',
-      );
+      await expect(middleware.handle(mockFn)).rejects.toThrow('boom');
       expect(mockSnapClient.getPreferences).toHaveBeenCalled();
       expect(mockTranslator.load).toHaveBeenCalledWith('en');
+      expect(mockLogger.error).toHaveBeenCalledWith(error);
+    });
+
+    it('wraps a non-Error thrown value by stringifying it', async () => {
+      const mockFn = jest.fn().mockRejectedValue('string failure');
+
+      await expect(middleware.handle(mockFn)).rejects.toThrow('string failure');
+      expect(mockLogger.error).toHaveBeenCalledWith('string failure');
+    });
+
+    it('wraps a thrown plain object by stringifying it', async () => {
+      const thrown = { foo: 'bar' };
+      const mockFn = jest.fn().mockRejectedValue(thrown);
+
+      await expect(middleware.handle(mockFn)).rejects.toThrow(
+        '[object Object]',
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(thrown);
     });
 
     it('handles error successfully if instance of BaseError', async () => {

--- a/packages/snap/src/handlers/HandlerMiddleware.ts
+++ b/packages/snap/src/handlers/HandlerMiddleware.ts
@@ -7,7 +7,7 @@ import {
   ResourceNotFoundError,
   UnauthorizedError,
   UserRejectedRequestError,
-  SnapError
+  SnapError,
 } from '@metamask/snaps-sdk';
 import { StructError } from 'superstruct';
 

--- a/packages/snap/src/handlers/HandlerMiddleware.ts
+++ b/packages/snap/src/handlers/HandlerMiddleware.ts
@@ -7,6 +7,7 @@ import {
   ResourceNotFoundError,
   UnauthorizedError,
   UserRejectedRequestError,
+  SnapError
 } from '@metamask/snaps-sdk';
 import { StructError } from 'superstruct';
 
@@ -113,10 +114,13 @@ export class HandlerMiddleware {
             error.data,
           );
         }
-        // this should never happen unless a BaseError is not thrown
-        const errMsg = messages.unexpected?.message ?? 'Unexpected error';
+        // Unknown error type — wrap in SnapError to preserve the original
+        // error's message and class info for observability (previously this
+        // branch replaced everything with a generic "Unexpected error"
+        // string, making cross-boundary errors like KeyringControllerError
+        // opaque in Sentry).
         this.#logger.error(error);
-        throw new InternalError(errMsg);
+        throw new SnapError(error instanceof Error ? error : String(error));
       }
     }
   }


### PR DESCRIPTION
## Summary
Errors thrown from outside the `BaseError` hierarchy (e.g. `KeyringControllerError` and other framework-level errors that cross the snap boundary) were being swallowed by `HandlerMiddleware` and replaced with a generic `InternalError("Unexpected error")`. This made these failures opaque in Sentry: every distinct upstream error collapsed to the same message, with no class name or stack to disambiguate them.

This PR wraps unknown errors in `SnapError` instead, preserving the original `Error` instance (and therefore its `name`, `message`, and stack) when one is available. Non-`Error` thrown values (strings, plain objects) are coerced via `String(error)` so the type contract of `SnapError` is satisfied without lying to the type system.

## Changes
- `HandlerMiddleware.ts`: replace the generic `InternalError("Unexpected error")` fallback with `new SnapError(error instanceof Error ? error : String(error))`. This is the path taken when the caught value is neither a `BaseError` nor a `StructError`.
- `HandlerMiddleware.test.ts`: replace the now-obsolete `'Unexpected error'` assertion. Add coverage for the three input shapes the new branch handles: `Error` instances, primitive thrown values, and plain objects.
- `snap.manifest.json`: version + shasum bump produced by `mm-snap build`. **Reviewer: consider whether this belongs in this PR or in a separate release commit.**

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the handler error boundary to throw `SnapError` instead of a generic `InternalError`, which may alter error types/messages observed by callers but is localized to unexpected-error paths.
> 
> **Overview**
> **Improves observability for unexpected handler failures.** `HandlerMiddleware` now logs and rethrows unknown (non-`BaseError`, non-`StructError`) failures as `SnapError`, preserving the original `Error` message/class when available and stringifying non-`Error` thrown values.
> 
> Tests are updated/expanded to assert preserved messages and cover `Error`, string, and plain-object throw cases, and the changelog records the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcfec757328b7adef67b0ec69d16295929aae3be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->