### PR TITLE
fix: include unconfirmed external-keychain change in displayed balance

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Preserve original error message and class when wrapping unknown errors at the handler boundary ([#600](https://github.com/MetaMask/snap-bitcoin-wallet/pull/600))
+- Display unconfirmed change to the external keychain (e.g. bridge/swap refunds) in the account balance so it no longer drops to zero while a partial-spend tx is pending ([#597](https://github.com/MetaMask/snap-bitcoin-wallet/issues/597))
 
 ## [1.10.1]
 

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Preserve original error message and class when wrapping unknown errors at the handler boundary ([#600](https://github.com/MetaMask/snap-bitcoin-wallet/pull/600))
-- Display unconfirmed change to the external keychain (e.g. bridge/swap refunds) in the account balance so it no longer drops to zero while a partial-spend tx is pending ([#597](https://github.com/MetaMask/snap-bitcoin-wallet/issues/597))
+- Display unconfirmed change to the external keychain (e.g. bridge/swap refunds) in the account balance so it no longer drops to zero while a partial-spend tx is pending ([#605](https://github.com/MetaMask/snap-bitcoin-wallet/pull/605))
 
 ## [1.10.1]
 

--- a/packages/snap/integration-test/keyring-request.test.ts
+++ b/packages/snap/integration-test/keyring-request.test.ts
@@ -6,6 +6,7 @@ import { assertIsConfirmationDialog, installSnap } from '@metamask/snaps-jest';
 import { BlockchainTestUtils } from './blockchain-utils';
 import { MNEMONIC, ORIGIN } from './constants';
 import { AccountCapability } from '../src/entities';
+import { Caip19Asset } from '../src/handlers/caip';
 import type { FillPsbtResponse } from '../src/handlers/KeyringRequestHandler';
 
 const ACCOUNT_INDEX = 3;
@@ -325,6 +326,34 @@ describe('KeyringRequestHandler', () => {
           txid: expect.any(String),
         },
       });
+
+      // Regression for issue #597: after broadcasting a partial-spend tx
+      // whose change lands on the external (public) keychain — as bridges
+      // and swaps do — the displayed balance must include that unconfirmed
+      // change. The wallet was funded with a single 10 BTC UTXO in
+      // `beforeAll`; the broadcast spends a small amount plus fee, so the
+      // change should be ~9.99 BTC, never 0.
+      const balanceResp = await snap.onKeyringRequest({
+        origin: ORIGIN,
+        method: 'keyring_getAccountBalances',
+        params: {
+          id: account.id,
+          assets: [Caip19Asset.Regtest],
+        },
+      });
+
+      const balanceResult = (
+        balanceResp.response as {
+          result: Record<string, { amount: string; unit: string }>;
+        }
+      ).result;
+      const amount = balanceResult[Caip19Asset.Regtest]?.amount;
+      expect(amount).toBeDefined();
+      // Bound from above as well: a stale fix where applyUnconfirmedTx
+      // no-ops would still report the original 10 BTC and pass a `> 9`
+      // check on its own, hiding the regression.
+      expect(parseFloat(amount as string)).toBeGreaterThan(9);
+      expect(parseFloat(amount as string)).toBeLessThan(10);
     });
 
     it('fails if invalid PSBT', async () => {

--- a/packages/snap/src/entities/balance.test.ts
+++ b/packages/snap/src/entities/balance.test.ts
@@ -1,0 +1,213 @@
+import type {
+  Amount,
+  LocalOutput,
+  WalletTx,
+  Transaction,
+} from '@metamask/bitcoindevkit';
+import { mock } from 'jest-mock-extended';
+
+import type { BitcoinAccount } from './account';
+import { computeDisplayBalanceSats } from './balance';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+const sat = (value: bigint): Amount =>
+  ({
+    to_sat: () => value,
+  }) as unknown as Amount;
+
+const mockUtxo = (opts: {
+  keychain: 'external' | 'internal';
+  txidString: string;
+  valueSats: bigint;
+}): LocalOutput =>
+  ({
+    keychain: opts.keychain,
+    outpoint: {
+      txid: { toString: () => opts.txidString },
+    },
+    txout: { value: sat(opts.valueSats) },
+  }) as unknown as LocalOutput;
+
+const mockWalletTx = (isConfirmed: boolean): WalletTx =>
+  ({
+    tx: {} as Transaction,
+    chain_position: { is_confirmed: isConfirmed },
+  }) as unknown as WalletTx;
+
+describe('computeDisplayBalanceSats', () => {
+  const buildAccount = (overrides: {
+    trustedSpendableSats: bigint;
+    utxos: LocalOutput[];
+    txByTxid: Record<string, WalletTx | undefined>;
+    sentByTxid: Record<string, bigint>;
+  }): BitcoinAccount => {
+    const account = mock<BitcoinAccount>();
+    Object.defineProperty(account, 'balance', {
+      get: () =>
+        ({
+          trusted_spendable: sat(overrides.trustedSpendableSats),
+        }) as never,
+    });
+    account.listUnspent.mockReturnValue(overrides.utxos);
+    account.getTransaction.mockImplementation((txid) => {
+      return overrides.txByTxid[txid];
+    });
+    account.sentAndReceived.mockImplementation((tx) => {
+      // Match by reference: find the txid whose mocked WalletTx.tx === tx.
+      for (const [txid, walletTx] of Object.entries(overrides.txByTxid)) {
+        if (walletTx && walletTx.tx === tx) {
+          return [sat(overrides.sentByTxid[txid] ?? 0n), sat(0n)];
+        }
+      }
+      return [sat(0n), sat(0n)];
+    });
+    return account;
+  };
+
+  it('returns trusted_spendable when there are no relevant unspents', () => {
+    const account = buildAccount({
+      trustedSpendableSats: 100n,
+      utxos: [],
+      txByTxid: {},
+      sentByTxid: {},
+    });
+
+    expect(computeDisplayBalanceSats(account)).toBe(100n);
+  });
+
+  it('skips internal-keychain unspents (already in trusted_pending)', () => {
+    const utxo = mockUtxo({
+      keychain: 'internal',
+      txidString: 'tx_internal',
+      valueSats: 50n,
+    });
+    const account = buildAccount({
+      trustedSpendableSats: 100n,
+      utxos: [utxo],
+      txByTxid: { tx_internal: mockWalletTx(false) },
+      sentByTxid: { tx_internal: 200n },
+    });
+
+    expect(computeDisplayBalanceSats(account)).toBe(100n);
+  });
+
+  it('skips external-keychain unspents whose tx is already confirmed', () => {
+    const utxo = mockUtxo({
+      keychain: 'external',
+      txidString: 'tx_confirmed',
+      valueSats: 50n,
+    });
+    const account = buildAccount({
+      trustedSpendableSats: 100n,
+      utxos: [utxo],
+      txByTxid: { tx_confirmed: mockWalletTx(true) },
+      sentByTxid: { tx_confirmed: 200n },
+    });
+
+    expect(computeDisplayBalanceSats(account)).toBe(100n);
+  });
+
+  it('skips external-keychain unspents from foreign transactions (sent === 0)', () => {
+    const utxo = mockUtxo({
+      keychain: 'external',
+      txidString: 'tx_incoming',
+      valueSats: 50n,
+    });
+    const account = buildAccount({
+      trustedSpendableSats: 100n,
+      utxos: [utxo],
+      txByTxid: { tx_incoming: mockWalletTx(false) },
+      sentByTxid: { tx_incoming: 0n },
+    });
+
+    expect(computeDisplayBalanceSats(account)).toBe(100n);
+  });
+
+  it('includes external-keychain change from our own broadcasts (issue #597)', () => {
+    const utxo = mockUtxo({
+      keychain: 'external',
+      txidString: 'tx_self',
+      valueSats: 999_900_243n,
+    });
+    const account = buildAccount({
+      trustedSpendableSats: 0n,
+      utxos: [utxo],
+      txByTxid: { tx_self: mockWalletTx(false) },
+      sentByTxid: { tx_self: 1_000_000_000n },
+    });
+
+    expect(computeDisplayBalanceSats(account)).toBe(999_900_243n);
+  });
+
+  it('skips unspents whose parent tx is unknown (defensive)', () => {
+    const utxo = mockUtxo({
+      keychain: 'external',
+      txidString: 'tx_missing',
+      valueSats: 50n,
+    });
+    const account = buildAccount({
+      trustedSpendableSats: 100n,
+      utxos: [utxo],
+      txByTxid: {},
+      sentByTxid: {},
+    });
+
+    expect(computeDisplayBalanceSats(account)).toBe(100n);
+  });
+
+  it('sums trusted_spendable and multiple qualifying external unspents', () => {
+    const owned = mockUtxo({
+      keychain: 'external',
+      txidString: 'tx_self',
+      valueSats: 50n,
+    });
+    const skippedInternal = mockUtxo({
+      keychain: 'internal',
+      txidString: 'tx_int',
+      valueSats: 70n,
+    });
+    const skippedConfirmed = mockUtxo({
+      keychain: 'external',
+      txidString: 'tx_conf',
+      valueSats: 30n,
+    });
+    const skippedIncoming = mockUtxo({
+      keychain: 'external',
+      txidString: 'tx_in',
+      valueSats: 20n,
+    });
+    const ownedSecond = mockUtxo({
+      keychain: 'external',
+      txidString: 'tx_self2',
+      valueSats: 25n,
+    });
+
+    const account = buildAccount({
+      trustedSpendableSats: 100n,
+      utxos: [
+        owned,
+        skippedInternal,
+        skippedConfirmed,
+        skippedIncoming,
+        ownedSecond,
+      ],
+      txByTxid: {
+        tx_self: mockWalletTx(false),
+        tx_int: mockWalletTx(false),
+        tx_conf: mockWalletTx(true),
+        tx_in: mockWalletTx(false),
+        tx_self2: mockWalletTx(false),
+      },
+      sentByTxid: {
+        tx_self: 100n,
+        tx_int: 100n,
+        tx_conf: 100n,
+        tx_in: 0n,
+        tx_self2: 100n,
+      },
+    });
+
+    expect(computeDisplayBalanceSats(account)).toBe(100n + 50n + 25n);
+  });
+});

--- a/packages/snap/src/entities/balance.ts
+++ b/packages/snap/src/entities/balance.ts
@@ -1,0 +1,46 @@
+import type { BitcoinAccount } from './account';
+
+/**
+ * Compute the spendable balance to display to the user, in satoshis.
+ *
+ * BDK's `Balance.trusted_spendable` only counts unconfirmed change UTXOs
+ * landing on the *internal* keychain. When the snap fills a partner-supplied
+ * PSBT (bridge/swap), the change output's script is dictated by the template
+ * and typically drains to the user's *external* (public) address — so BDK
+ * conservatively classifies that change as `untrusted_pending` and the user
+ * sees their balance flash to zero until the tx confirms.
+ *
+ * We extend BDK's "trusted spendable" by also counting any unconfirmed UTXO
+ * whose parent transaction was created by this wallet itself (i.e. spends
+ * from one of our own inputs). Genuinely untrusted incoming unconfirmed
+ * funds from third parties remain excluded.
+ *
+ * @param account - The Bitcoin account to inspect.
+ * @returns The available balance in satoshis.
+ */
+export function computeDisplayBalanceSats(account: BitcoinAccount): bigint {
+  let sats = account.balance.trusted_spendable.to_sat();
+
+  for (const utxo of account.listUnspent()) {
+    // Already counted by BDK as `trusted_pending` (change to internal keychain)
+    // or as `confirmed` once anchored.
+    if (utxo.keychain === 'internal') {
+      continue;
+    }
+
+    const walletTx = account.getTransaction(utxo.outpoint.txid.toString());
+    if (!walletTx || walletTx.chain_position.is_confirmed) {
+      continue;
+    }
+
+    // `sent > 0` means the wallet contributed inputs to this transaction,
+    // so the output landing back on our own external script is trusted —
+    // a third party cannot have produced it without one of our keys.
+    const [sent] = account.sentAndReceived(walletTx.tx);
+    if (sent.to_sat() > 0n) {
+      sats += utxo.txout.value.to_sat();
+    }
+  }
+
+  return sats;
+}

--- a/packages/snap/src/entities/index.ts
+++ b/packages/snap/src/entities/index.ts
@@ -1,4 +1,5 @@
 export * from './account';
+export * from './balance';
 export type * from './config';
 export * from './chain';
 export * from './currency';

--- a/packages/snap/src/handlers/KeyringHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringHandler.test.ts
@@ -48,6 +48,12 @@ jest.mock('@metamask/bitcoindevkit', () => {
     Address: {
       from_script: jest.fn(),
     },
+    Amount: {
+      from_sat: (sats: bigint) => ({
+        to_btc: () => Number(sats) / 100_000_000,
+        to_sat: () => sats,
+      }),
+    },
   };
 });
 
@@ -65,13 +71,16 @@ describe('KeyringHandler', () => {
   const mockAccount = mock<BitcoinAccount>({
     id: 'some-id',
     addressType: 'p2wpkh',
-    balance: { trusted_spendable: { to_btc: () => 1 } },
+    balance: {
+      trusted_spendable: { to_btc: () => 1, to_sat: () => 100_000_000n },
+    },
     network: 'bitcoin',
     derivationPath: ['myEntropy', "84'", "0'", "0'"],
     entropySource: 'myEntropy',
     accountIndex: 0,
     publicAddress: mockAddress,
     capabilities: [AccountCapability.SignPsbt, AccountCapability.ComputeFee],
+    listUnspent: () => [],
   });
   const defaultAddressType: AddressType = 'p2wpkh';
 

--- a/packages/snap/src/handlers/KeyringHandler.ts
+++ b/packages/snap/src/handlers/KeyringHandler.ts
@@ -1,4 +1,5 @@
 import type { AddressType } from '@metamask/bitcoindevkit';
+import { Amount } from '@metamask/bitcoindevkit';
 import {
   BtcAccountType,
   BtcScope,
@@ -45,6 +46,7 @@ import {
 
 import type { BitcoinAccount, Logger, SnapClient } from '../entities';
 import {
+  computeDisplayBalanceSats,
   FormatError,
   InexistentMethodError,
   networkToCurrencyUnit,
@@ -316,7 +318,9 @@ export class KeyringHandler implements Keyring {
     id: string,
   ): Promise<Record<CaipAssetType, Balance>> {
     const account = await this.#accountsUseCases.get(id);
-    const balance = account.balance.trusted_spendable.to_btc().toString();
+    const balance = Amount.from_sat(computeDisplayBalanceSats(account))
+      .to_btc()
+      .toString();
 
     return {
       [networkToCaip19[account.network]]: {

--- a/packages/snap/src/infra/SnapClientAdapter.ts
+++ b/packages/snap/src/infra/SnapClientAdapter.ts
@@ -1,4 +1,5 @@
 import type { WalletTx } from '@metamask/bitcoindevkit';
+import { Amount } from '@metamask/bitcoindevkit';
 import type { JsonSLIP10Node } from '@metamask/key-tree';
 import { SLIP10Node } from '@metamask/key-tree';
 import { KeyringEvent } from '@metamask/keyring-api';
@@ -15,6 +16,7 @@ import { DialogType } from '@metamask/snaps-sdk';
 
 import type { BaseError, BitcoinAccount, SnapClient } from '../entities';
 import {
+  computeDisplayBalanceSats,
   TrackingSnapEvent,
   networkToCurrencyUnit,
   AssertionError,
@@ -111,7 +113,9 @@ export class SnapClientAdapter implements SnapClient {
         ...acc,
         [account.id]: {
           [networkToCaip19[account.network]]: {
-            amount: account.balance.trusted_spendable.to_btc().toString(),
+            amount: Amount.from_sat(computeDisplayBalanceSats(account))
+              .to_btc()
+              .toString(),
             unit: networkToCurrencyUnit[account.network],
           },
         },


### PR DESCRIPTION
## Explanation

When a partner-supplied PSBT (bridge / swap) drains change to the user's external (public) address, BDK classifies that unconfirmed UTXO as `untrusted_pending` rather than `trusted_pending`, so the snap's previous display path (`Balance.trusted_spendable`) reported zero until the tx confirmed.

Introduce `computeDisplayBalanceSats` which adds back any unconfirmed external-keychain UTXO whose parent transaction was authored by this wallet (`sentAndReceived(tx).sent > 0`). Genuinely untrusted incoming unconfirmed funds remain excluded. Wired into the two display sites:

- `KeyringHandler.getAccountBalances`
- `SnapClientAdapter.emitAccountBalancesUpdatedEvent`

Spend-validation paths (`SendFlowUseCases`, `validation.ts`) intentionally keep using `trusted_spendable`, since BDK's coin selection only spends confirmed + internal-keychain pending UTXOs anyway.

Adds unit tests for the new helper and an integration regression in `keyring-request.test.ts` that funds a single UTXO, broadcasts a partial-spend PSBT whose change lands on the external keychain, and asserts the post-broadcast balance is between the change and the original amount.

Closes #597.

## Screenshots
The snap now counts unconfirmed external-keychain UTXOs from own-authored txs
<img width="377" height="861" alt="Screenshot 2026-05-11 at 20 46 39" src="https://github.com/user-attachments/assets/ecf8586c-8092-40b7-b171-0557ab76ef5c" />

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the balance shown to users by counting a subset of unconfirmed UTXOs, which could affect UI/portfolio consistency if the trust heuristic is wrong or BDK semantics change. Scope is limited to display/event paths and is covered by new unit + integration regression tests.
> 
> **Overview**
> Fixes a regression where the displayed balance could drop to zero after broadcasting a partner-supplied PSBT whose change output lands on the *external* keychain.
> 
> Introduces `computeDisplayBalanceSats`, which extends `trusted_spendable` by adding unconfirmed external-keychain UTXOs *only when* their parent transaction is identified as wallet-authored (`sentAndReceived(...).sent > 0`). This new computation is wired into `KeyringHandler.getAccountBalances` and `SnapClientAdapter.emitAccountBalancesUpdatedEvent`.
> 
> Adds focused unit tests for the helper plus an integration regression asserting post-broadcast balance reflects unconfirmed external change (between the original funded amount and the expected change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6404f44194b3ee0efd129df2bf2303493e8758f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->