### PR TITLE
fix: show filled PSBT in signPsbt confirmation

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `createMany` use case ([#610](https://github.com/MetaMask/snap-bitcoin-wallet/pull/610))
 
+### Fixed
+
+- Show the filled PSBT in the `signPsbt` confirmation dialog so the displayed transaction matches the one being signed ([#606](https://github.com/MetaMask/snap-bitcoin-wallet/pull/606))
+
 ## [1.11.0]
 
 ### Added

--- a/packages/snap/src/handlers/KeyringRequestHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringRequestHandler.test.ts
@@ -111,6 +111,7 @@ describe('KeyringRequestHandler', () => {
         SignPsbtRequest,
       );
       expect(mockAccountsUseCases.get).toHaveBeenCalledWith('account-id');
+      expect(mockAccountsUseCases.fillPsbt).not.toHaveBeenCalled();
       expect(mockConfirmationRepository.insertSignPsbt).toHaveBeenCalledWith(
         mockAccount,
         mockPsbt,
@@ -121,7 +122,7 @@ describe('KeyringRequestHandler', () => {
         'account-id',
         mockPsbt,
         'metamask',
-        mockOptions,
+        { fill: false, broadcast: true },
         3,
       );
       expect(result).toStrictEqual({
@@ -194,6 +195,77 @@ describe('KeyringRequestHandler', () => {
       });
     });
 
+    it('fills the PSBT before showing the confirmation when options.fill is true', async () => {
+      const fillOptions = { fill: true, broadcast: true };
+      const fillRequest = mock<KeyringRequest>({
+        origin,
+        request: {
+          method: AccountCapability.SignPsbt,
+          params: {
+            ...accountParam,
+            psbt: 'psbtBase64',
+            feeRate: 3,
+            options: fillOptions,
+          },
+        },
+        account: 'account-id',
+      });
+
+      const filledPsbt = mock<Psbt>({
+        toString: jest.fn().mockReturnValue('filledPsbtBase64'),
+      });
+      const psbtForConfirmation = mock<Psbt>();
+      const psbtForSigning = mock<Psbt>();
+      mockAccountsUseCases.fillPsbt.mockResolvedValue(filledPsbt);
+      mockAccountsUseCases.signPsbt.mockResolvedValue({
+        psbt: 'signedPsbtBase64',
+        txid: mock<Txid>({
+          toString: jest.fn().mockReturnValue('txid'),
+        }),
+        canBeMalleable: false,
+      });
+      jest
+        .mocked(parsePsbt)
+        .mockReturnValueOnce(mockPsbt)
+        .mockReturnValueOnce(psbtForConfirmation)
+        .mockReturnValueOnce(psbtForSigning);
+
+      await handler.route(fillRequest);
+
+      const fillOrder =
+        mockAccountsUseCases.fillPsbt.mock.invocationCallOrder[0];
+      const insertOrder =
+        mockConfirmationRepository.insertSignPsbt.mock.invocationCallOrder[0];
+      const signOrder =
+        mockAccountsUseCases.signPsbt.mock.invocationCallOrder[0];
+
+      expect(fillOrder).toBeLessThan(insertOrder as number);
+      expect(insertOrder).toBeLessThan(signOrder as number);
+
+      expect(mockAccountsUseCases.fillPsbt).toHaveBeenCalledWith(
+        'account-id',
+        mockPsbt,
+        3,
+      );
+      expect(parsePsbt).toHaveBeenNthCalledWith(1, 'psbtBase64');
+      expect(parsePsbt).toHaveBeenNthCalledWith(2, 'filledPsbtBase64');
+      expect(parsePsbt).toHaveBeenNthCalledWith(3, 'filledPsbtBase64');
+      expect(mockConfirmationRepository.insertSignPsbt).toHaveBeenCalledWith(
+        mockAccount,
+        psbtForConfirmation,
+        'metamask',
+        fillOptions,
+      );
+      expect(mockAccountsUseCases.signPsbt).toHaveBeenCalledWith(
+        'account-id',
+        psbtForSigning,
+        'metamask',
+        { fill: false, broadcast: true },
+        3,
+      );
+      expect(psbtForSigning).not.toBe(psbtForConfirmation);
+    });
+
     it('returns null txid when signPsbt result has no txid', async () => {
       mockAccountsUseCases.signPsbt.mockResolvedValue({
         psbt: 'psbtBase64',
@@ -220,6 +292,30 @@ describe('KeyringRequestHandler', () => {
       expect(mockAccountsUseCases.signPsbt).not.toHaveBeenCalled();
     });
 
+    it('does not show confirmation or sign if fillPsbt fails', async () => {
+      const fillOptions = { fill: true, broadcast: true };
+      const fillRequest = mock<KeyringRequest>({
+        origin,
+        request: {
+          method: AccountCapability.SignPsbt,
+          params: {
+            ...accountParam,
+            psbt: 'psbtBase64',
+            feeRate: 3,
+            options: fillOptions,
+          },
+        },
+        account: 'account-id',
+      });
+      const error = new Error('fee rate too high');
+      mockAccountsUseCases.fillPsbt.mockRejectedValue(error);
+
+      await expect(handler.route(fillRequest)).rejects.toThrow(error);
+
+      expect(mockConfirmationRepository.insertSignPsbt).not.toHaveBeenCalled();
+      expect(mockAccountsUseCases.signPsbt).not.toHaveBeenCalled();
+    });
+
     it('propagates errors from parsePsbt', async () => {
       const error = new Error('parsePsbt');
       jest.mocked(parsePsbt).mockImplementationOnce(() => {
@@ -231,7 +327,11 @@ describe('KeyringRequestHandler', () => {
           ...mockRequest,
           request: {
             ...mockRequest.request,
-            params: { ...accountParam, psbt: 'invalidPsbt' },
+            params: {
+              ...accountParam,
+              psbt: 'invalidPsbt',
+              options: mockOptions,
+            },
           },
         }),
       ).rejects.toThrow(error);

--- a/packages/snap/src/handlers/KeyringRequestHandler.ts
+++ b/packages/snap/src/handlers/KeyringRequestHandler.ts
@@ -128,26 +128,34 @@ export class KeyringRequestHandler {
     options: { fill: boolean; broadcast: boolean },
     feeRate?: number,
   ): Promise<KeyringResponse> {
-    const psbt = parsePsbt(psbtBase64);
     const account = await this.#accountsUseCases.get(id);
+
+    const psbtBase64ToSign = options.fill
+      ? (
+          await this.#accountsUseCases.fillPsbt(
+            id,
+            parsePsbt(psbtBase64),
+            feeRate,
+          )
+        ).toString()
+      : psbtBase64;
 
     await this.#confirmationRepository.insertSignPsbt(
       account,
-      psbt,
+      parsePsbt(psbtBase64ToSign),
       origin,
       options,
     );
 
-    // Creates a fresh PSBT from the original base64 because the original PSBT is mutated by the confirmation repository
     const {
       psbt: signedPsbt,
       txid,
       canBeMalleable,
     } = await this.#accountsUseCases.signPsbt(
       id,
-      parsePsbt(psbtBase64),
+      parsePsbt(psbtBase64ToSign),
       origin,
-      options,
+      { ...options, fill: false },
       feeRate,
     );
     // Invariant: signPsbt sets txid and canBeMalleable together (when broadcast


### PR DESCRIPTION
## Explanation

The signPsbt confirmation showed the unfilled template PSBT supplied by the dApp, while a freshly filled PSBT (with the dApp's feeRate) was the one actually signed. The user could not see the inputs, real fee, or feeRate before approving, allowing a malicious dApp to spoof the displayed transaction.

Fill the PSBT before showing the confirmation when options.fill is true, and pass fill=false to the inner signPsbt so the use case does not double-fill (which would re-introduce divergence between displayed and signed transaction).

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## Screenshots

### BEFORE
<img width="1267" height="891" alt="Screenshot 2026-05-28 at 01 18 36" src="https://github.com/user-attachments/assets/58267aec-fbc0-4ed3-bd99-8eed8cd99413" />

### AFTER
<img width="1270" height="948" alt="image" src="https://github.com/user-attachments/assets/4c3bd6ae-290c-449c-8ff2-daa3f9431a6b" />

<img width="401" height="578" alt="Screenshot 2026-05-11 at 19 42 11" src="https://github.com/user-attachments/assets/b26a3f62-94d0-497a-be41-1671f0803c12" />


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Fixes a user-facing security/consent gap where approval could not reflect the real transaction when fill was deferred until after confirmation.
> 
> **Overview**
> When **`signPsbt`** is called with **`options.fill: true`**, the handler now **fills the PSBT before** the confirmation UI, so users see the same inputs, fee, and fee rate that will be signed—not the dApp’s unfilled template.
> 
> The inner **`signPsbt`** call is invoked with **`fill: false`** so filling does not run twice and the confirmed transaction cannot diverge from what gets signed. If **`fillPsbt`** fails, neither confirmation nor signing runs.
> 
> Tests cover fill-before-confirm ordering, no double-fill, and failure paths; the snap **changelog** records the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34515f5c90066d6596c5204bb570a9163b44e768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->