### PR TITLE
feat: warn on self-sends in sendTransfer confirmation

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Show a self-send warning in the send confirmation when the recipient address belongs to the sending account ([#607](https://github.com/MetaMask/snap-bitcoin-wallet/pull/607))
 - Show a confirmation dialog before signing a PSBT from KeyringHandler and sending a transfer ([#591](https://github.com/MetaMask/snap-bitcoin-wallet/pull/591))
 - Add `resolveAccountAddress` method to KeyringHandler for dApp connectivity ([#590](https://github.com/MetaMask/snap-bitcoin-wallet/pull/590))
 

--- a/packages/snap/locales/de.json
+++ b/packages/snap/locales/de.json
@@ -208,6 +208,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "Transaktionsanfrage"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "Anfrage von"
     }

--- a/packages/snap/locales/el.json
+++ b/packages/snap/locales/el.json
@@ -208,6 +208,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "Αίτημα συναλλαγής"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "Ζητήθηκε από"
     }

--- a/packages/snap/locales/en.json
+++ b/packages/snap/locales/en.json
@@ -211,6 +211,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "Transaction request"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The funds will stay in your account."
+    },
     "confirmation.requestOrigin": {
       "message": "Request from"
     },

--- a/packages/snap/locales/en.json
+++ b/packages/snap/locales/en.json
@@ -215,7 +215,7 @@
       "message": "Sending to your own address"
     },
     "confirmation.signAndSendTransaction.selfSend.description": {
-      "message": "The recipient address belongs to this wallet. The funds will stay in your account."
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
     },
     "confirmation.requestOrigin": {
       "message": "Request from"

--- a/packages/snap/locales/es.json
+++ b/packages/snap/locales/es.json
@@ -208,6 +208,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "Solicitud de transacción"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "Solicitud de"
     }

--- a/packages/snap/locales/es_419.json
+++ b/packages/snap/locales/es_419.json
@@ -208,6 +208,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "Solicitud de transacción"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "Solicitud de"
     }

--- a/packages/snap/locales/fr.json
+++ b/packages/snap/locales/fr.json
@@ -208,6 +208,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "Demande de transaction"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "Demande de la part de"
     }

--- a/packages/snap/locales/hi.json
+++ b/packages/snap/locales/hi.json
@@ -208,6 +208,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "ट्रांसेक्शन रिक्वेस्ट"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "इनसे मिला अनुरोध"
     }

--- a/packages/snap/locales/id.json
+++ b/packages/snap/locales/id.json
@@ -208,6 +208,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "Permintaan transaksi"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "Permintaan dari"
     }

--- a/packages/snap/locales/ja.json
+++ b/packages/snap/locales/ja.json
@@ -208,6 +208,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "トランザクションリクエスト"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "要求元"
     }

--- a/packages/snap/locales/ko.json
+++ b/packages/snap/locales/ko.json
@@ -178,6 +178,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "트랜잭션 요청"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "요청자:"
     }

--- a/packages/snap/locales/pt.json
+++ b/packages/snap/locales/pt.json
@@ -178,6 +178,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "Solicitação de transação"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "Solicitação de"
     }

--- a/packages/snap/locales/ru.json
+++ b/packages/snap/locales/ru.json
@@ -178,6 +178,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "Запрос транзакции"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "Запрос от"
     }

--- a/packages/snap/locales/tl.json
+++ b/packages/snap/locales/tl.json
@@ -178,6 +178,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "Hiling na transaksyon"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "Kahilingan mula sa/kay"
     }

--- a/packages/snap/locales/tr.json
+++ b/packages/snap/locales/tr.json
@@ -178,6 +178,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "İşlem talebi"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "Talebi gönderen"
     }

--- a/packages/snap/locales/vi.json
+++ b/packages/snap/locales/vi.json
@@ -178,6 +178,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "Yêu cầu giao dịch"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "Yêu cầu từ"
     }

--- a/packages/snap/locales/zh_CN.json
+++ b/packages/snap/locales/zh_CN.json
@@ -178,6 +178,12 @@
     "confirmation.signAndSendTransaction.title": {
       "message": "交易请求"
     },
+    "confirmation.signAndSendTransaction.selfSend.title": {
+      "message": "Sending to your own address"
+    },
+    "confirmation.signAndSendTransaction.selfSend.description": {
+      "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
+    },
     "confirmation.requestOrigin": {
       "message": "请求来自"
     }

--- a/packages/snap/messages.json
+++ b/packages/snap/messages.json
@@ -213,7 +213,7 @@
     "message": "Sending to your own address"
   },
   "confirmation.signAndSendTransaction.selfSend.description": {
-    "message": "The recipient address belongs to this wallet. The funds will stay in your account."
+    "message": "The recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply."
   },
   "confirmation.requestOrigin": {
     "message": "Request from"

--- a/packages/snap/messages.json
+++ b/packages/snap/messages.json
@@ -209,6 +209,12 @@
   "confirmation.signAndSendTransaction.title": {
     "message": "Transaction request"
   },
+  "confirmation.signAndSendTransaction.selfSend.title": {
+    "message": "Sending to your own address"
+  },
+  "confirmation.signAndSendTransaction.selfSend.description": {
+    "message": "The recipient address belongs to this wallet. The funds will stay in your account."
+  },
   "confirmation.requestOrigin": {
     "message": "Request from"
   },

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "brY11ouz4B0rvJfVVtPYkLGxWqfp4i9eAde0MABrk74=",
+    "shasum": "wwbWFYmkXL1VZpor9Zro1GhiTm5C3X4yb/K8DZHr38U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "1jbPT93y4v8JjV5Sj8zdfhhk9Eq1GJrTjSjciRYsl4c=",
+    "shasum": "brY11ouz4B0rvJfVVtPYkLGxWqfp4i9eAde0MABrk74=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "wwbWFYmkXL1VZpor9Zro1GhiTm5C3X4yb/K8DZHr38U=",
+    "shasum": "ULNv7Bt/BuxJkLiIo7x79kO0vVLtnZj8CxGoa2bEQ+M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/entities/send-flow.ts
+++ b/packages/snap/src/entities/send-flow.ts
@@ -18,7 +18,7 @@ export type ConfirmSendFormContext = {
   locale: string;
   psbt: string;
   origin?: string;
-  isMine?: boolean;
+  isMine: boolean;
 };
 
 export type SendFormContext = {

--- a/packages/snap/src/entities/send-flow.ts
+++ b/packages/snap/src/entities/send-flow.ts
@@ -18,6 +18,7 @@ export type ConfirmSendFormContext = {
   locale: string;
   psbt: string;
   origin?: string;
+  isMine?: boolean;
 };
 
 export type SendFormContext = {

--- a/packages/snap/src/infra/jsx/unified-send-flow/UnifiedSendFormView.tsx
+++ b/packages/snap/src/infra/jsx/unified-send-flow/UnifiedSendFormView.tsx
@@ -2,6 +2,7 @@ import { Psbt } from '@metamask/bitcoindevkit';
 import type { SnapComponent } from '@metamask/snaps-sdk/jsx';
 import {
   Address,
+  Banner,
   Heading,
   Link,
   Section,
@@ -43,6 +44,7 @@ export const UnifiedSendFormView: SnapComponent<UnifiedSendFormViewProps> = ({
     recipient,
     explorerUrl,
     origin,
+    isMine,
   } = context;
 
   const psbt = Psbt.from_string(context.psbt);
@@ -59,6 +61,17 @@ export const UnifiedSendFormView: SnapComponent<UnifiedSendFormViewProps> = ({
           </Heading>
           <Box>{null}</Box>
         </Box>
+
+        {isMine ? (
+          <Banner
+            title={t('confirmation.signAndSendTransaction.selfSend.title')}
+            severity="warning"
+          >
+            <SnapText>
+              {t('confirmation.signAndSendTransaction.selfSend.description')}
+            </SnapText>
+          </Banner>
+        ) : null}
 
         <Section>
           <Box>

--- a/packages/snap/src/store/JSXConfirmationRepository.test.tsx
+++ b/packages/snap/src/store/JSXConfirmationRepository.test.tsx
@@ -28,6 +28,7 @@ import { UnifiedSendFormView } from '../infra/jsx/unified-send-flow';
 jest.mock('@metamask/bitcoindevkit', () => ({
   Address: {
     from_script: jest.fn(),
+    from_string: jest.fn(),
   },
 }));
 
@@ -110,10 +111,12 @@ describe('JSXConfirmationRepository', () => {
   });
 
   describe('insertSendTransfer', () => {
+    const mockRecipientScript = mock<ScriptBuf>();
     const mockAccount = mock<BitcoinAccount>({
       id: 'account-id',
       network: 'bitcoin',
       publicAddress: mock<Address>({ toString: () => 'fromAddress' }),
+      isMine: () => false,
     });
     const mockPsbt = mock<Psbt>({
       toString: () => 'serialized-psbt',
@@ -131,6 +134,9 @@ describe('JSXConfirmationRepository', () => {
       mockChainClient.getExplorerUrl.mockReturnValue('https://mempool.space');
       mockRatesClient.spotPrices.mockResolvedValue(
         mock<SpotPrice>({ price: 50000 }),
+      );
+      MockedBdkAddress.from_string.mockReturnValue(
+        mock<Address>({ script_pubkey: mockRecipientScript }),
       );
     });
 
@@ -151,6 +157,7 @@ describe('JSXConfirmationRepository', () => {
         locale: 'en',
         psbt: 'serialized-psbt',
         origin,
+        isMine: false,
       };
 
       expect(mockSnapClient.getPreferences).toHaveBeenCalled();
@@ -170,6 +177,44 @@ describe('JSXConfirmationRepository', () => {
       );
     });
 
+    it('marks the recipient as isMine when it belongs to the account', async () => {
+      const selfSendAccount = mock<BitcoinAccount>({
+        id: 'account-id',
+        network: 'bitcoin',
+        publicAddress: mock<Address>({ toString: () => 'fromAddress' }),
+        isMine: () => true,
+      });
+
+      await repo.insertSendTransfer(
+        selfSendAccount,
+        mockPsbt,
+        recipient,
+        origin,
+      );
+
+      expect(MockedBdkAddress.from_string).toHaveBeenCalledWith(
+        recipient.address,
+        selfSendAccount.network,
+      );
+      expect(mockSnapClient.createInterface).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ isMine: true }),
+      );
+    });
+
+    it('defaults isMine to false when the recipient address fails to parse', async () => {
+      MockedBdkAddress.from_string.mockImplementation(() => {
+        throw new Error('Invalid address');
+      });
+
+      await repo.insertSendTransfer(mockAccount, mockPsbt, recipient, origin);
+
+      expect(mockSnapClient.createInterface).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ isMine: false }),
+      );
+    });
+
     it('throws UserActionError if the user cancels', async () => {
       mockSnapClient.displayConfirmation.mockResolvedValue(false);
       await expect(
@@ -182,6 +227,7 @@ describe('JSXConfirmationRepository', () => {
         id: 'account-id',
         network: 'testnet',
         publicAddress: mock<Address>({ toString: () => 'fromAddress' }),
+        isMine: () => false,
       });
 
       await repo.insertSendTransfer(

--- a/packages/snap/src/store/JSXConfirmationRepository.tsx
+++ b/packages/snap/src/store/JSXConfirmationRepository.tsx
@@ -88,6 +88,17 @@ export class JSXConfirmationRepository implements ConfirmationRepository {
     const { locale, currency: fiatCurrency } =
       await this.#snapClient.getPreferences();
 
+    let isMine = false;
+    try {
+      const recipientScript = BdkAddress.from_string(
+        recipient.address,
+        account.network,
+      ).script_pubkey;
+      isMine = account.isMine(recipientScript);
+    } catch {
+      isMine = false;
+    }
+
     const context: ConfirmSendFormContext = {
       from: account.publicAddress.toString(),
       explorerUrl: this.#chainClient.getExplorerUrl(account.network),
@@ -99,6 +110,7 @@ export class JSXConfirmationRepository implements ConfirmationRepository {
       locale,
       psbt: psbt.toString(),
       origin,
+      isMine,
     };
 
     const messages = await this.#translator.load(locale);

--- a/packages/snap/src/use-cases/SendFlowUseCases.test.ts
+++ b/packages/snap/src/use-cases/SendFlowUseCases.test.ts
@@ -986,6 +986,37 @@ describe('SendFlowUseCases', () => {
       expect(result).toBe(mockTransaction);
     });
 
+    it('marks the recipient as isMine when the address belongs to the account', async () => {
+      const recipientScript = {} as any;
+      (Address.from_string as jest.Mock).mockReturnValue({
+        script_pubkey: recipientScript,
+      });
+      mockAccount.isMine.mockReturnValue(true);
+
+      await useCases.confirmSendFlow(mockAccount, amount, toAddress);
+
+      expect(Address.from_string).toHaveBeenCalledWith(
+        toAddress,
+        mockAccount.network,
+      );
+      expect(mockAccount.isMine).toHaveBeenCalledWith(recipientScript);
+      expect(mockSendFlowRepository.insertConfirmSendForm).toHaveBeenCalledWith(
+        expect.objectContaining({ isMine: true }),
+      );
+    });
+
+    it('defaults isMine to false when the recipient address fails to parse', async () => {
+      (Address.from_string as jest.Mock).mockImplementation(() => {
+        throw new Error('Invalid address');
+      });
+
+      await useCases.confirmSendFlow(mockAccount, amount, toAddress);
+
+      expect(mockSendFlowRepository.insertConfirmSendForm).toHaveBeenCalledWith(
+        expect.objectContaining({ isMine: false }),
+      );
+    });
+
     it('builds a drain transaction when amount equals balance', async () => {
       const balanceAmount = mock<Amount>();
       balanceAmount.to_sat.mockReturnValue(BigInt(10000));

--- a/packages/snap/src/use-cases/SendFlowUseCases.ts
+++ b/packages/snap/src/use-cases/SendFlowUseCases.ts
@@ -111,6 +111,17 @@ export class SendFlowUseCases {
     const psbt = templatePsbt.finish();
     const currency = networkToCurrencyUnit[account.network];
 
+    let isMine = false;
+    try {
+      const recipientScript = Address.from_string(
+        toAddress,
+        account.network,
+      ).script_pubkey;
+      isMine = account.isMine(recipientScript);
+    } catch {
+      isMine = false;
+    }
+
     // TODO: add all the necessary properties we need here
     const context: ConfirmSendFormContext = {
       from: account.publicAddress.toString(),
@@ -122,6 +133,7 @@ export class SendFlowUseCases {
       exchangeRate: await this.#getExchangeRate(account.network, fiatCurrency),
       network: account.network,
       locale,
+      isMine,
     };
 
     const interfaceId =


### PR DESCRIPTION
## Explanation

The dApp-initiated `sendTransfer` keyring flow built `ConfirmSendFormContext` without checking whether the recipient address belonged to the sending account. The companion `signPsbt` flow already runs `account.isMine` on each output (so it can label change vs. recipient), but `sendTransfer` did not — so `UnifiedSendFormView` rendered self-sends as ordinary outgoing transfers with no indication that the funds were going back to the same wallet.

This change brings `sendTransfer` to parity with `signPsbt`:

- `JSXConfirmationRepository.insertSendTransfer` derives `isMine` from the recipient's `script_pubkey` (`BdkAddress.from_string(recipient.address, account.network).script_pubkey` → `account.isMine(...)`), with a `try/catch` defaulting to `false` on parse failure — same defensive pattern used in `insertSignPsbt`.
- `UnifiedSendFormView` renders a warning `Banner` above the estimated changes when `isMine === true` ("Sending to your own address — the recipient address belongs to this wallet. The amount will stay in your account, but network fees still apply.").
- The same `isMine` derivation is added to the in-app `SendFlowUseCases.confirmSendFlow` path so both producers of `ConfirmSendFormContext` (the dApp keyring path and the in-app send flow) behave consistently.
- `isMine` is a required field on `ConfirmSendFormContext` so the type system enforces parity for any future producer.
- The two new locale keys are added to all 16 locale files (English text as a placeholder for non-EN locales until translations land), since the translator falls back per-file rather than per-key.

A note on visual treatment: `signPsbt`'s confirmation labels per-output rows as "Change" when `isMine` is true. `sendTransfer` enforces exactly one recipient, so labelling the only output as "Change" would be misleading — it's the actual recipient. A top-level Banner is the closest equivalent to the "alert" the suggestion describes, and is functionally equivalent (and arguably more prominent) than per-row labelling.

## Screenshots

### Before

<img width="363" height="982" alt="Screenshot 2026-05-11 at 18 17 23" src="https://github.com/user-attachments/assets/c4b8836c-7ef8-4a6e-83e4-90cdaa486299" />

### After

<img width="370" height="866" alt="Screenshot 2026-05-11 at 17 24 00" src="https://github.com/user-attachments/assets/50a1bd1f-6be1-4a48-9e54-669fc29b5872" />


## References

Closes the security-audit suggestion: *"sendTransfer Confirmation Does Not Check for Self-Sends"*.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only disclosure on existing send flows; no change to signing, broadcasting, or authorization logic beyond clearer confirmation copy.
> 
> **Overview**
> Send confirmations now detect when the recipient is one of the wallet’s own addresses and surface that to the user before they confirm.
> 
> **`ConfirmSendFormContext`** gains a required **`isMine`** flag. Both **`JSXConfirmationRepository.insertSendTransfer`** (dApp/keyring path) and **`SendFlowUseCases.confirmSendFlow`** (in-app path) set it by parsing the recipient with **`Address.from_string`**, then **`account.isMine(script_pubkey)`**, defaulting to **`false`** if parsing fails—matching the defensive pattern already used for PSBT outputs.
> 
> **`UnifiedSendFormView`** shows a warning **`Banner`** when **`isMine`** is true (new locale keys in **`messages.json`** and all locale files). The changelog records this under 1.11.0 **Changed**.
> 
> Tests cover **`isMine`** true/false and parse failures for both repository and use-case paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e0c5f7708280d71cddd8fa809c70a350dfd6de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->