### PR TITLE
[Batch accounts 6/6] Document keyring_createAccounts support

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for `keyring_createAccounts` method to enable batch account creation ([#601](https://github.com/MetaMask/snap-bitcoin-wallet/pull/601))
+
 ### Changed
 
 - Show a confirmation dialog before signing a PSBT from KeyringHandler and sending a transfer ([#591](https://github.com/MetaMask/snap-bitcoin-wallet/pull/591))
 - Add `resolveAccountAddress` method to KeyringHandler for dApp connectivity ([#590](https://github.com/MetaMask/snap-bitcoin-wallet/pull/590))
+- Bump `@metamask/keyring-api` from `^21.3.0` to `^22.0.0` ([#601](https://github.com/MetaMask/snap-bitcoin-wallet/pull/601))
+- Bump `@metamask/keyring-snap-sdk` from `^7.1.1` to `^8.0.0` ([#601](https://github.com/MetaMask/snap-bitcoin-wallet/pull/601))
 
 ### Fixed
 


### PR DESCRIPTION
Stack part 6 of 6 split from #601. Adds the changelog entry for keyring_createAccounts support and the related keyring dependency bumps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating the changelog; no runtime code paths are modified.
> 
> **Overview**
> Documents upcoming support for batch account creation via `keyring_createAccounts` in `packages/snap/CHANGELOG.md`.
> 
> Also notes the associated dependency upgrades to `@metamask/keyring-api@^22.0.0` and `@metamask/keyring-snap-sdk@^8.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3274ce7292253fbf182904fa0d65defa1106130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->