### PR TITLE
fix: validate feeRate as a finite number >= 1

### DIFF
--- a/packages/snap/keyring.openrpc.json
+++ b/packages/snap/keyring.openrpc.json
@@ -21,7 +21,7 @@
           "name": "feeRate",
           "description": "Optional fee rate in sat/vB.",
           "required": false,
-          "schema": { "type": "number" }
+          "schema": { "type": "number", "minimum": 1 }
         },
         {
           "name": "options",
@@ -65,7 +65,7 @@
           "name": "feeRate",
           "description": "Optional fee rate in sat/vB.",
           "required": false,
-          "schema": { "type": "number" }
+          "schema": { "type": "number", "minimum": 1 }
         }
       ],
       "result": {
@@ -95,7 +95,7 @@
           "name": "feeRate",
           "description": "Optional fee rate in sat/vB.",
           "required": false,
-          "schema": { "type": "number" }
+          "schema": { "type": "number", "minimum": 1 }
         }
       ],
       "result": {
@@ -159,7 +159,7 @@
           "name": "feeRate",
           "description": "Optional fee rate in sat/vB.",
           "required": false,
-          "schema": { "type": "number" }
+          "schema": { "type": "number", "minimum": 1 }
         }
       ],
       "result": {

--- a/packages/snap/src/handlers/validation.test.ts
+++ b/packages/snap/src/handlers/validation.test.ts
@@ -105,7 +105,7 @@ describe('validation', () => {
         ['Infinity', Infinity],
         ['-Infinity', -Infinity],
       ])('rejects %s feeRate', (_description, feeRate) => {
-        expect(() => assertParams(feeRate)).toThrow();
+        expect(() => assertParams(feeRate)).toThrow('At path: feeRate');
       });
     });
   });

--- a/packages/snap/src/handlers/validation.test.ts
+++ b/packages/snap/src/handlers/validation.test.ts
@@ -1,9 +1,14 @@
 import type { AddressType } from '@metamask/bitcoindevkit';
 import { mock } from 'jest-mock-extended';
+import { assert } from 'superstruct';
 
 import type { BitcoinAccount } from '../entities';
 import {
+  ComputeFeeRequest,
+  FillPsbtRequest,
   parseRewardsMessage,
+  SendTransferRequest,
+  SignPsbtRequest,
   validateDustLimit,
   validateSelectedAccounts,
 } from './validation';
@@ -19,6 +24,92 @@ jest.mock('@metamask/bitcoindevkit', () => ({
 }));
 
 describe('validation', () => {
+  describe('feeRate request validation', () => {
+    const account = { account: { address: 'test-account-address' } };
+    const optionalFeeRate = (feeRate?: number) =>
+      feeRate === undefined ? {} : { feeRate };
+    const requestCases: {
+      name: string;
+      assertParams: (feeRate?: number) => void;
+    }[] = [
+      {
+        name: 'SignPsbtRequest',
+        assertParams: (feeRate?: number) =>
+          assert(
+            {
+              ...account,
+              psbt: 'psbtBase64',
+              ...optionalFeeRate(feeRate),
+              options: { fill: false, broadcast: true },
+            },
+            SignPsbtRequest,
+          ),
+      },
+      {
+        name: 'FillPsbtRequest',
+        assertParams: (feeRate?: number) =>
+          assert(
+            {
+              ...account,
+              psbt: 'psbtBase64',
+              ...optionalFeeRate(feeRate),
+            },
+            FillPsbtRequest,
+          ),
+      },
+      {
+        name: 'ComputeFeeRequest',
+        assertParams: (feeRate?: number) =>
+          assert(
+            {
+              ...account,
+              psbt: 'psbtBase64',
+              ...optionalFeeRate(feeRate),
+            },
+            ComputeFeeRequest,
+          ),
+      },
+      {
+        name: 'SendTransferRequest',
+        assertParams: (feeRate?: number) =>
+          assert(
+            {
+              ...account,
+              recipients: [
+                {
+                  address: 'bcrt1qstku2y3pfh9av50lxj55arm8r5gj8tf2yv5nxz',
+                  amount: '1000',
+                },
+              ],
+              ...optionalFeeRate(feeRate),
+            },
+            SendTransferRequest,
+          ),
+      },
+    ];
+
+    describe.each(requestCases)('$name', ({ assertParams }) => {
+      it('accepts an omitted feeRate', () => {
+        expect(() => assertParams()).not.toThrow();
+      });
+
+      it.each([1, 2.4, 3])('accepts feeRate %p', (feeRate) => {
+        expect(() => assertParams(feeRate)).not.toThrow();
+      });
+
+      it.each([
+        ['zero', 0],
+        ['below minimum', 0.5],
+        ['negative', -5],
+        ['NaN', NaN],
+        ['Infinity', Infinity],
+        ['-Infinity', -Infinity],
+      ])('rejects %s feeRate', (_description, feeRate) => {
+        expect(() => assertParams(feeRate)).toThrow();
+      });
+    });
+  });
+
   describe('validateDustLimit', () => {
     const makeAccount = (addressType: AddressType) =>
       mock<BitcoinAccount>({ addressType });

--- a/packages/snap/src/handlers/validation.ts
+++ b/packages/snap/src/handlers/validation.ts
@@ -99,10 +99,16 @@ const WalletAccountStruct = object({
   address: string(),
 });
 
+export const FeeRateStruct = refine(
+  number(),
+  'fee rate greater than or equal to 1',
+  (value) => Number.isFinite(value) && value >= 1,
+);
+
 export const SignPsbtRequest = object({
   account: WalletAccountStruct,
   psbt: string(),
-  feeRate: optional(number()),
+  feeRate: optional(FeeRateStruct),
   options: object({
     fill: boolean(),
     broadcast: boolean(),
@@ -112,7 +118,7 @@ export const SignPsbtRequest = object({
 export const ComputeFeeRequest = object({
   account: WalletAccountStruct,
   psbt: string(),
-  feeRate: optional(number()),
+  feeRate: optional(FeeRateStruct),
 });
 
 export const BroadcastPsbtRequest = object({
@@ -123,7 +129,7 @@ export const BroadcastPsbtRequest = object({
 export const FillPsbtRequest = object({
   account: WalletAccountStruct,
   psbt: string(),
-  feeRate: optional(number()),
+  feeRate: optional(FeeRateStruct),
 });
 
 export const SendTransferRequest = object({
@@ -134,7 +140,7 @@ export const SendTransferRequest = object({
       amount: string(),
     }),
   ),
-  feeRate: optional(number()),
+  feeRate: optional(FeeRateStruct),
 });
 
 export const GetUtxoRequest = object({


### PR DESCRIPTION
## Explanation

This pull request strengthens validation for the `feeRate` parameter across several Bitcoin Snap request types. It enforces a minimum value of 1 for `feeRate` in both the OpenRPC schema and runtime validation, and adds comprehensive tests to ensure invalid values are rejected.

**Validation improvements for `feeRate`:**

* Added a custom `FeeRateStruct` in `validation.ts` to ensure `feeRate` is a finite number greater than or equal to 1, and applied it to `SignPsbtRequest`, `FillPsbtRequest`, `ComputeFeeRequest`, and `SendTransferRequest` schemas.

**OpenRPC schema updates:**

* Updated `keyring.openrpc.json` to require `feeRate` be a number with a minimum value of 1 for all relevant methods, ensuring consistent API documentation and validation.

**Testing enhancements:**

* Added parameterized tests in `validation.test.ts` to verify that valid `feeRate` values (≥1) are accepted and invalid values (e.g., 0, negative, NaN, Infinity) are rejected for all affected request types.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Input-validation hardening only; callers sending invalid feeRate values will now fail early instead of reaching fee logic.
> 
> **Overview**
> Tightens optional **`feeRate`** (sat/vB) validation for Bitcoin Snap keyring requests **`signPsbt`**, **`fillPsbt`**, **`computeFee`**, and **`sendTransfer`**.
> 
> Runtime schemas now use **`FeeRateStruct`**: the value must be a **finite number ≥ 1** (still optional when omitted). **`keyring.openrpc.json`** documents the same rule via **`minimum: 1`** on those methods. New unit tests assert valid rates (e.g. `1`, `2.4`) pass and invalid ones (`0`, `0.5`, negatives, `NaN`, `±Infinity`) fail with a **`feeRate`** path error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3514d04239b74474ea16dbc95a4435f19bac640c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->