### PR TITLE
fix: include external service details in connection errors

### DIFF
--- a/packages/snap/src/handlers/HandlerMiddleware.test.ts
+++ b/packages/snap/src/handlers/HandlerMiddleware.test.ts
@@ -6,6 +6,7 @@ import {
   type SnapClient,
   type Translator,
   BaseError,
+  ExternalServiceError,
 } from '../entities';
 import { HandlerMiddleware } from './HandlerMiddleware';
 
@@ -25,6 +26,7 @@ describe('HandlerMiddleware', () => {
   );
 
   beforeEach(() => {
+    jest.clearAllMocks();
     mockSnapClient.getPreferences.mockResolvedValue({
       locale: 'en',
     } as GetPreferencesResult);
@@ -78,6 +80,21 @@ describe('HandlerMiddleware', () => {
       expect(mockSnapClient.getPreferences).toHaveBeenCalled();
       expect(mockTranslator.load).toHaveBeenCalledWith('en');
       expect(mockLogger.error).toHaveBeenCalledWith(error, error.data);
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(error);
+    });
+
+    it('includes the concrete external service failure in the returned error message', async () => {
+      const error = new ExternalServiceError('Failed to synchronize account', {
+        account: 'account-1',
+      });
+      const mockFn = jest.fn().mockRejectedValue(error);
+      mockTranslator.load.mockResolvedValue({
+        'error.3000': { message: 'Connection error' },
+      });
+
+      await expect(middleware.handle(mockFn)).rejects.toThrow(
+        'Connection error: Failed to synchronize account',
+      );
       expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(error);
     });
   });

--- a/packages/snap/src/handlers/HandlerMiddleware.ts
+++ b/packages/snap/src/handlers/HandlerMiddleware.ts
@@ -96,7 +96,10 @@ export class HandlerMiddleware {
 
           // Internal errors that we should not expose to the user: Equivalent to 5xx errors
         } else if (error instanceof ExternalServiceError) {
-          throw new DisconnectedError(errMsg, error.data);
+          throw new DisconnectedError(
+            `${errMsg}: ${error.message}`,
+            error.data,
+          );
         } else if (
           error instanceof WalletError ||
           error instanceof StorageError ||


### PR DESCRIPTION
## Explanation

This pull request enhances error handling in the `HandlerMiddleware` by improving how external service errors are reported and tested. The main focus is on providing more informative error messages to users and ensuring robust test coverage for these scenarios.

**Error Handling Improvements:**

* Updated the error thrown for `ExternalServiceError` in `HandlerMiddleware` to include both the localized error message and the specific external service failure message, resulting in clearer and more actionable error feedback for users.

**Testing Enhancements:**

* Added a new test case to verify that the returned error message for external service failures includes both the localized message and the concrete failure reason.
* Ensured all mocks are cleared before each test to avoid cross-test contamination, improving test reliability.
* Imported `ExternalServiceError` in the test file to support the new test case.


**Before/After:**
Before error thrown:
`Connection error`

After error thrown:
```
Connection error: Failed to synchronize account
Connection error: Failed to perform initial full scan
Connection error: Failed to broadcast transaction
Connection error: Failed to fetch fee estimates
Connection error: Network failure while fetching spot prices
Connection error: Network failure while fetching historical prices
```

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, user-facing error-message change in snap middleware with no auth or data-path changes; slightly more operational detail exposed to clients.
> 
> **Overview**
> **Snap handler middleware** now surfaces the underlying failure when mapping `ExternalServiceError` to a `DisconnectedError`: the thrown message is **`{localized message}: {original error.message}`** instead of only the localized string (e.g. *Connection error: Failed to synchronize account*).
> 
> Tests add coverage for that message shape and call **`jest.clearAllMocks()`** in `beforeEach` for more reliable isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d563f3e4f012a6ac61f912a27739af5e8086196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->