### PR TITLE
Revert "1.12.0 (#619)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-wallet-snap-monorepo",
-  "version": "1.12.0",
+  "version": "1.11.0",
   "private": true,
   "description": "",
   "homepage": "https://github.com/MetaMask/snap-bitcoin-wallet#readme",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/bitcoin-wallet-test-dapp",
-  "version": "1.12.0",
+  "version": "1.10.1",
   "private": true,
   "description": "A sample dapp to test the Bitcoin wallet Snap.",
   "license": "(MIT-0 OR Apache-2.0)",

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.12.0]
-
 ### Added
 
 - Add `createMany` use case ([#610](https://github.com/MetaMask/snap-bitcoin-wallet/pull/610))
@@ -603,8 +601,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add CI for lint and test ([#2](https://github.com/MetaMask/bitcoin/pull/2))
 - feat: init commit
 
-[Unreleased]: https://github.com/MetaMask/snap-bitcoin-wallet/compare/v1.12.0...HEAD
-[1.12.0]: https://github.com/MetaMask/snap-bitcoin-wallet/compare/v1.11.0...v1.12.0
+[Unreleased]: https://github.com/MetaMask/snap-bitcoin-wallet/compare/v1.11.0...HEAD
 [1.11.0]: https://github.com/MetaMask/snap-bitcoin-wallet/compare/v1.10.1...v1.11.0
 [1.10.1]: https://github.com/MetaMask/snap-bitcoin-wallet/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/MetaMask/snap-bitcoin-wallet/compare/v1.9.0...v1.10.0

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/bitcoin-wallet-snap",
-  "version": "1.12.0",
+  "version": "1.11.0",
   "description": "A Bitcoin wallet Snap.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Explanation

Reverts the `1.12.0` release (#619). The release was merged but the publish workflow failed in release-notes generation with `Error: Specified release version does not exist: '1.12.0'`, so nothing was published to npm (`latest` is still `1.11.0`) and no `v1.12.0` tag was created.

Reverting restores `main` to the pre-release state (`1.11.0` / `site` `1.10.1`, snap changelog entries back under `[Unreleased]`). After this merges, we'll re-run "Create release PR" and fold **both** the `snap` and `site` changelogs (or drop the `site` bump) before merging the fresh release PR.

## References

- Reverts #619
- Failed run: https://github.com/MetaMask/snap-bitcoin-wallet/actions/runs/26802363589

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by updating changelogs for packages I've changed
- [ ] I've introduced breaking changes in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a7ba11986eebc1d28809c92fb05737ac53b2f099. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->