### PR TITLE
fix: update npm workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
     name: Publish release
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-release.yml
     with:
       LOG_LEVEL: ${{ vars.LOG_LEVEL }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       NPM_TOKEN:
-        required: true
+        required: false
       SLACK_WEBHOOK_URL:
         required: true
       ESPLORA_BITCOIN:
@@ -89,8 +89,7 @@ jobs:
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Dry Run Publish
-        # Omit npm-token token to perform dry-run publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
@@ -101,6 +100,9 @@ jobs:
     environment: npm-publish
     runs-on: ubuntu-latest
     needs: publish-npm-dry-run
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -118,10 +120,13 @@ jobs:
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
-          # This `NPM_TOKEN` needs to be manually set per-repository.
-          # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.
+          # This `NPM_TOKEN` needs to be manually set to publish a package for
+          # the first time only.
+          # Look in the repository settings under "Environments", and set this
+          # token in the `npm-publish` environment, and delete it after the
+          # initial publish.
           npm-token: ${{ secrets.NPM_TOKEN }}
         env:
           SKIP_PREPACK: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,6 +27,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     permissions:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,6 @@
+# Allowlist for Git repositories that can be used as dependencies. We set it to
+# an empty array to disallow all Git dependencies, as we don't use any and they
+# can be a security risk.
 approvedGitRepositories: []
 
 compressionLevel: mixed
@@ -6,11 +9,24 @@ enableGlobalCache: false
 
 enableScripts: false
 
-enableTelemetry: 0
+enableTelemetry: false
+
+logFilters:
+  - code: YN0004
+    level: discard
 
 nodeLinker: node-modules
 
+# Configure the NPM minimal age gate to 3 days, meaning packages must be at
+# least 3 days old to be installed.
 npmMinimalAgeGate: 4320
+
+# Override the minimal age gate, allowing certain packages to be installed
+# regardless of their publish age.
+npmPreapprovedPackages:
+  - '@metamask/*'
+  - '@metamask-previews/*'
+  - '@lavamoat/*'
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,4 @@
-approvedGitRepositories:
-  - "**"
+approvedGitRepositories: []
 
 compressionLevel: mixed
 

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,7 +10,7 @@ enableTelemetry: 0
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 0
+npmMinimalAgeGate: 4320
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,6 @@
+approvedGitRepositories:
+  - "**"
+
 compressionLevel: mixed
 
 enableGlobalCache: false
@@ -8,6 +11,8 @@ enableTelemetry: 0
 
 nodeLinker: node-modules
 
+npmMinimalAgeGate: 0
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
-    spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'
+    spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "resolutions": {
     "@metamask/snaps-sdk": "^11.0.0"
   },
-  "packageManager": "yarn@4.9.1",
+  "packageManager": "yarn@4.16.0",
   "engines": {
     "node": ">= 20"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10
 
 "@adobe/css-tools@npm:^4.0.1":


### PR DESCRIPTION
## Explanation

This pull request updates the release workflow and Yarn configuration to improve publishing and dependency management. Key changes include upgrading the npm publish GitHub Action, updating Yarn settings for repository approval and npm publishing, and clarifying the use of the npm token for publishing.

**Release workflow improvements:**

* Upgraded the npm publish GitHub Action from `MetaMask/action-npm-publish@v5` to `@v6` in both the dry run and actual publish steps, ensuring the latest features and fixes are used.
* Updated the requirement for the `NPM_TOKEN` secret to be optional (`required: false`) and clarified documentation to indicate it's only needed for the initial publish, after which it can be deleted.
* Added explicit permissions (`contents: read`, `id-token: write`) to the publish job for improved security and compatibility with the latest GitHub Actions best practices.

**Yarn configuration updates:**

* Added `approvedGitRepositories: ["**"]` to `.yarnrc.yml` to allow all git repositories, and set `npmMinimalAgeGate: 0` to disable age restrictions on npm packages.
* Updated the Yarn version in `package.json` from `4.9.1` to `4.16.0` to ensure compatibility with the latest features and bug fixes.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production npm publish path and CI install policy; misconfigured OIDC or the new age gate could block releases or installs of non-preapproved packages.
> 
> **Overview**
> Updates **release publishing** to `MetaMask/action-npm-publish@v6` and aligns GitHub Actions permissions for **OIDC-based npm publish** (`id-token: write` on the caller `publish-release` job and the `publish-npm` job). The reusable workflow now sets default `contents: read`, makes **`NPM_TOKEN` optional** at the workflow-call boundary, and revises comments so the token is documented as **first-publish-only** (dry run no longer relies on omitting the token).
> 
> **Yarn 4.16.0** is pinned in `package.json`, with `.yarnrc.yml` hardening: **no git URL dependencies** (`approvedGitRepositories: []`), a **3-day npm minimal age gate** with **`@metamask/*`**, previews, and **`@lavamoat/*` preapproved**, telemetry off, and discarding **YN0004** install warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ce956f8b1e131f9296587b4a5d039d2edc35b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->