### PR TITLE
Fix: guard against webassembly issue

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Throw a clear `WalletError` when WebAssembly is unavailable (e.g. iOS Lockdown Mode) instead of crashing with an obscure `"undefined is not an object (evaluating 'WebAssembly.instantiate')"` error ([#628](https://github.com/MetaMask/snap-bitcoin-wallet/pull/628))
+- Throw a `WalletError` when `WebAssembly` is unavailable (e.g. iOS Lockdown Mode) ([#628](https://github.com/MetaMask/snap-bitcoin-wallet/pull/628))
+  - The snap was previously crashing with a confusing `"undefined is not an object (evaluating 'WebAssembly.instantiate')"` error.
 
 ## [1.13.0]
 

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `signProofOfOwnership` client request method ([#626](https://github.com/MetaMask/snap-bitcoin-wallet/pull/626))
   - This method silently signs `metamask:proof-of-ownership:<nonce>:<address>` messages with the account's BIP-322 signer
 
+### Fixed
+
+- Throw a clear `WalletError` when WebAssembly is unavailable (e.g. iOS Lockdown Mode) instead of crashing with an obscure `"undefined is not an object (evaluating 'WebAssembly.instantiate')"` error ([#626](https://github.com/MetaMask/snap-bitcoin-wallet/pull/626))
+
 ## [1.13.0]
 
 ### Changed

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,17 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Throw a `WalletError` when `WebAssembly` is unavailable (e.g. iOS Lockdown Mode) ([#628](https://github.com/MetaMask/snap-bitcoin-wallet/pull/628))
+  - The snap was previously crashing with a confusing `"undefined is not an object (evaluating 'WebAssembly.instantiate')"` error.
+
 ## [1.14.0]
 
 ### Added
 
 - Add `signProofOfOwnership` client request method ([#626](https://github.com/MetaMask/snap-bitcoin-wallet/pull/626))
   - This method silently signs `metamask:proof-of-ownership:<nonce>:<address>` messages with the account's BIP-322 signer
-
-### Fixed
-
-- Throw a `WalletError` when `WebAssembly` is unavailable (e.g. iOS Lockdown Mode) ([#628](https://github.com/MetaMask/snap-bitcoin-wallet/pull/628))
-  - The snap was previously crashing with a confusing `"undefined is not an object (evaluating 'WebAssembly.instantiate')"` error.
 
 ## [1.13.0]
 

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Throw a clear `WalletError` when WebAssembly is unavailable (e.g. iOS Lockdown Mode) instead of crashing with an obscure `"undefined is not an object (evaluating 'WebAssembly.instantiate')"` error ([#626](https://github.com/MetaMask/snap-bitcoin-wallet/pull/626))
+- Throw a clear `WalletError` when WebAssembly is unavailable (e.g. iOS Lockdown Mode) instead of crashing with an obscure `"undefined is not an object (evaluating 'WebAssembly.instantiate')"` error ([#628](https://github.com/MetaMask/snap-bitcoin-wallet/pull/628))
 
 ## [1.13.0]
 

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-bitcoin-wallet.git"
   },
   "source": {
-    "shasum": "Mqa9EOV9G6g7Ox8UGUYXxuXD5+kypzP+xjQ2v8zWW4c=",
+    "shasum": "MTzKFh6HogVOYFf+j53R/wr/HNjocn0FpRA4E1mX0Yc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/infra/BdkAccountAdapter.test.ts
+++ b/packages/snap/src/infra/BdkAccountAdapter.test.ts
@@ -1,0 +1,193 @@
+// TODO: enable when this is merged: https://github.com/rustwasm/wasm-bindgen/issues/1818
+/* eslint-disable @typescript-eslint/naming-convention */
+import type {
+  ChangeSet,
+  DescriptorPair,
+  Network,
+} from '@metamask/bitcoindevkit';
+import { Wallet } from '@metamask/bitcoindevkit';
+import { mock } from 'jest-mock-extended';
+
+import { WalletError } from '../entities';
+import { BdkAccountAdapter } from './BdkAccountAdapter';
+
+jest.mock('@metamask/bitcoindevkit', () => ({
+  FeeRate: jest.fn(),
+  OutPoint: { from_string: jest.fn() },
+  SignOptions: jest.fn(),
+  Txid: { from_string: jest.fn() },
+  UnconfirmedTx: jest.fn(),
+  Wallet: {
+    create: jest.fn(),
+    load: jest.fn(),
+  },
+}));
+
+describe('BdkAccountAdapter', () => {
+  const mockWallet = mock<Wallet>();
+  const mockId = 'test-id';
+  const mockDerivationPath = ['m', "84'", "0'", "0'"];
+  const mockDescriptors = mock<DescriptorPair>({
+    external: 'ext-desc',
+    internal: 'int-desc',
+  });
+  const mockChangeSet = mock<ChangeSet>();
+  const mockNetwork: Network = 'bitcoin';
+
+  beforeEach(() => {
+    jest.mocked(Wallet.create).mockReturnValue(mockWallet);
+    jest.mocked(Wallet.load).mockReturnValue(mockWallet);
+  });
+
+  describe('WebAssembly availability guard', () => {
+    // eslint-disable-next-line no-restricted-globals -- needed to save/restore the WebAssembly global in tests
+    let originalWebAssembly: typeof WebAssembly;
+
+    beforeEach(() => {
+      originalWebAssembly = globalThis.WebAssembly;
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'WebAssembly', {
+        configurable: true,
+        value: originalWebAssembly,
+        writable: true,
+      });
+    });
+
+    /** Simulates an environment where WebAssembly is unavailable (e.g., iOS Lockdown Mode). */
+    function disableWebAssembly(): void {
+      Object.defineProperty(globalThis, 'WebAssembly', {
+        configurable: true,
+        value: undefined,
+        writable: true,
+      });
+    }
+
+    describe('create', () => {
+      it('throws WalletError when WebAssembly is unavailable', () => {
+        disableWebAssembly();
+
+        expect(() =>
+          BdkAccountAdapter.create(
+            mockId,
+            mockDerivationPath,
+            mockDescriptors,
+            mockNetwork,
+          ),
+        ).toThrow(WalletError);
+      });
+
+      it('error message mentions iOS Lockdown Mode', () => {
+        disableWebAssembly();
+
+        expect(() =>
+          BdkAccountAdapter.create(
+            mockId,
+            mockDerivationPath,
+            mockDescriptors,
+            mockNetwork,
+          ),
+        ).toThrow(/Lockdown Mode/u);
+      });
+
+      it('does not call Wallet.create when WebAssembly is unavailable', () => {
+        disableWebAssembly();
+
+        expect(() =>
+          BdkAccountAdapter.create(
+            mockId,
+            mockDerivationPath,
+            mockDescriptors,
+            mockNetwork,
+          ),
+        ).toThrow(WalletError);
+        expect(Wallet.create).not.toHaveBeenCalled();
+      });
+
+      it('calls Wallet.create when WebAssembly is available', () => {
+        BdkAccountAdapter.create(
+          mockId,
+          mockDerivationPath,
+          mockDescriptors,
+          mockNetwork,
+        );
+
+        expect(Wallet.create).toHaveBeenCalledWith(
+          mockNetwork,
+          mockDescriptors.external,
+          mockDescriptors.internal,
+        );
+      });
+
+      it('returns a BdkAccountAdapter instance when WebAssembly is available', () => {
+        const result = BdkAccountAdapter.create(
+          mockId,
+          mockDerivationPath,
+          mockDescriptors,
+          mockNetwork,
+        );
+
+        expect(result).toBeInstanceOf(BdkAccountAdapter);
+      });
+    });
+
+    describe('load', () => {
+      it('throws WalletError when WebAssembly is unavailable', () => {
+        disableWebAssembly();
+
+        expect(() =>
+          BdkAccountAdapter.load(mockId, mockDerivationPath, mockChangeSet),
+        ).toThrow(WalletError);
+      });
+
+      it('error message mentions iOS Lockdown Mode', () => {
+        disableWebAssembly();
+
+        expect(() =>
+          BdkAccountAdapter.load(mockId, mockDerivationPath, mockChangeSet),
+        ).toThrow(/Lockdown Mode/u);
+      });
+
+      it('does not call Wallet.load when WebAssembly is unavailable', () => {
+        disableWebAssembly();
+
+        expect(() =>
+          BdkAccountAdapter.load(mockId, mockDerivationPath, mockChangeSet),
+        ).toThrow(WalletError);
+        expect(Wallet.load).not.toHaveBeenCalled();
+      });
+
+      it('calls Wallet.load without descriptors', () => {
+        BdkAccountAdapter.load(mockId, mockDerivationPath, mockChangeSet);
+
+        expect(Wallet.load).toHaveBeenCalledWith(mockChangeSet);
+      });
+
+      it('calls Wallet.load with descriptors', () => {
+        BdkAccountAdapter.load(
+          mockId,
+          mockDerivationPath,
+          mockChangeSet,
+          mockDescriptors,
+        );
+
+        expect(Wallet.load).toHaveBeenCalledWith(
+          mockChangeSet,
+          mockDescriptors.external,
+          mockDescriptors.internal,
+        );
+      });
+
+      it('returns a BdkAccountAdapter instance when WebAssembly is available', () => {
+        const result = BdkAccountAdapter.load(
+          mockId,
+          mockDerivationPath,
+          mockChangeSet,
+        );
+
+        expect(result).toBeInstanceOf(BdkAccountAdapter);
+      });
+    });
+  });
+});

--- a/packages/snap/src/infra/BdkAccountAdapter.test.ts
+++ b/packages/snap/src/infra/BdkAccountAdapter.test.ts
@@ -1,4 +1,3 @@
-// TODO: enable when this is merged: https://github.com/rustwasm/wasm-bindgen/issues/1818
 /* eslint-disable @typescript-eslint/naming-convention */
 import type {
   ChangeSet,

--- a/packages/snap/src/infra/BdkAccountAdapter.ts
+++ b/packages/snap/src/infra/BdkAccountAdapter.ts
@@ -52,12 +52,23 @@ export class BdkAccountAdapter implements BitcoinAccount {
     this.#capabilities = Object.values(AccountCapability);
   }
 
+  static #assertWebAssemblyAvailable(): void {
+    // eslint-disable-next-line no-restricted-globals -- WebAssembly is a valid endowment in the snap execution environment (endowment:webassembly)
+    if (typeof WebAssembly === 'undefined') {
+      throw new WalletError(
+        'WebAssembly is not available in this environment. ' +
+          'If iOS Lockdown Mode is enabled, Bitcoin wallet functionality is not supported.',
+      );
+    }
+  }
+
   static create(
     id: string,
     derivationPath: string[],
     descriptors: DescriptorPair,
     network: Network,
   ): BdkAccountAdapter {
+    BdkAccountAdapter.#assertWebAssemblyAvailable();
     return new BdkAccountAdapter(
       id,
       derivationPath,
@@ -71,6 +82,7 @@ export class BdkAccountAdapter implements BitcoinAccount {
     walletData: ChangeSet,
     descriptors?: DescriptorPair,
   ): BdkAccountAdapter {
+    BdkAccountAdapter.#assertWebAssemblyAvailable();
     // Load with signer
     if (descriptors) {
       return new BdkAccountAdapter(

--- a/packages/snap/src/infra/BdkAccountAdapter.ts
+++ b/packages/snap/src/infra/BdkAccountAdapter.ts
@@ -34,6 +34,19 @@ import {
 } from '../entities';
 import { BdkTxBuilderAdapter } from './BdkTxBuilderAdapter';
 
+/**
+ * Throws a {@link WalletError} if WebAssembly is not available in the current environment.
+ */
+function assertWebAssemblyAvailable(): void {
+  // eslint-disable-next-line no-restricted-globals -- WebAssembly is a valid endowment in the snap execution environment (endowment:webassembly)
+  if (typeof WebAssembly === 'undefined') {
+    throw new WalletError(
+      'WebAssembly is not available in this environment. ' +
+        'If iOS Lockdown Mode is enabled, Bitcoin wallet functionality is not supported.',
+    );
+  }
+}
+
 export class BdkAccountAdapter implements BitcoinAccount {
   readonly #id: string;
 
@@ -52,23 +65,13 @@ export class BdkAccountAdapter implements BitcoinAccount {
     this.#capabilities = Object.values(AccountCapability);
   }
 
-  static #assertWebAssemblyAvailable(): void {
-    // eslint-disable-next-line no-restricted-globals -- WebAssembly is a valid endowment in the snap execution environment (endowment:webassembly)
-    if (typeof WebAssembly === 'undefined') {
-      throw new WalletError(
-        'WebAssembly is not available in this environment. ' +
-          'If iOS Lockdown Mode is enabled, Bitcoin wallet functionality is not supported.',
-      );
-    }
-  }
-
   static create(
     id: string,
     derivationPath: string[],
     descriptors: DescriptorPair,
     network: Network,
   ): BdkAccountAdapter {
-    BdkAccountAdapter.#assertWebAssemblyAvailable();
+    assertWebAssemblyAvailable();
     return new BdkAccountAdapter(
       id,
       derivationPath,
@@ -82,7 +85,7 @@ export class BdkAccountAdapter implements BitcoinAccount {
     walletData: ChangeSet,
     descriptors?: DescriptorPair,
   ): BdkAccountAdapter {
-    BdkAccountAdapter.#assertWebAssemblyAvailable();
+    assertWebAssemblyAvailable();
     // Load with signer
     if (descriptors) {
       return new BdkAccountAdapter(


### PR DESCRIPTION
## Explanation

This pull request improves error handling when WebAssembly is unavailable (such as in iOS Lockdown Mode), ensuring the application fails gracefully with a clear error message instead of an obscure crash. It introduces a guard in the `BdkAccountAdapter` to check for WebAssembly availability and updates both the implementation and test coverage accordingly.

**Error handling improvements:**

* Added a private static method `#assertWebAssemblyAvailable` to `BdkAccountAdapter` that throws a `WalletError` with a clear message if WebAssembly is not available, mentioning iOS Lockdown Mode. This guard is now called at the start of both the `create` and `load` static methods.
* Updated the changelog to document that a clear `WalletError` is thrown when WebAssembly is unavailable, replacing the previous obscure error.

**Test coverage:**

* Added comprehensive tests to `BdkAccountAdapter.test.ts` to verify that:
  - A `WalletError` is thrown when WebAssembly is unavailable,
  - The error message mentions iOS Lockdown Mode,
  - The underlying `Wallet.create`/`Wallet.load` methods are not called when WebAssembly is missing,
  - Normal behavior is preserved when WebAssembly is available.

## References

Fixes: [undefined is not an object (evaluating 'WebAssembly.instantiate')](https://metamask.sentry.io/issues/7042325378)

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive guard at wallet entry points only; normal WASM environments are unchanged and behavior is covered by new tests.
> 
> **Overview**
> Adds a **WebAssembly availability check** on `BdkAccountAdapter.create` and `load` so missing WASM (e.g. iOS Lockdown Mode) throws a **`WalletError`** with guidance instead of failing inside BDK with `WebAssembly.instantiate`.
> 
> New unit tests simulate `WebAssembly` being undefined and assert the error, Lockdown Mode wording, and that `Wallet.create` / `Wallet.load` are not invoked. The unreleased changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a5476917026ac564bf47c5b0b049aeb1dcb4ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->