### PR TITLE
chore: bump Yarn to 4.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "resolutions": {
     "@metamask/snaps-sdk": "^11.0.0"
   },
-  "packageManager": "yarn@4.16.0",
+  "packageManager": "yarn@4.17.0+sha512.c2957de2f9025ab14d63b24d0d8be1f1655810e22c341042c27f7ecd017b180ec12db73d69ac366d71b304ef9f069349ce462de96f04f8f1da317f4f762c95ae",
   "engines": {
     "node": ">= 20"
   },


### PR DESCRIPTION
## Why

Bumps the pinned Yarn version to `4.17.0` to satisfy the minimum **Yarn 4.16.0** requirement introduced by [`MetaMask/action-npm-publish` v6](https://github.com/MetaMask/action-npm-publish/blob/main/CHANGELOG.md#600). v6's publish script hard-fails on any Yarn below 4.16.0, so this is a prerequisite before that action can be upgraded (tracked separately under `me/update-action-npm-publish`).

## Changes

- `package.json`: `packageManager` -> `yarn@4.17.0` (was already on 4.16.0 on main, so this is a minor bump; no lockfile/`.yarnrc.yml` changes needed)

## Verification

- `yarn install --immutable` passes (lockfile consistent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)