### PR TITLE
chore: track JSX confirmation repository errors

### DIFF
--- a/packages/snap/src/store/JSXConfirmationRepository.test.tsx
+++ b/packages/snap/src/store/JSXConfirmationRepository.test.tsx
@@ -203,12 +203,16 @@ describe('JSXConfirmationRepository', () => {
     });
 
     it('defaults isMine to false when the recipient address fails to parse', async () => {
+      const addressError = new Error('Invalid address');
       MockedBdkAddress.from_string.mockImplementation(() => {
-        throw new Error('Invalid address');
+        throw addressError;
       });
 
       await repo.insertSendTransfer(mockAccount, mockPsbt, recipient, origin);
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(
+        addressError,
+      );
       expect(mockSnapClient.createInterface).toHaveBeenCalledWith(
         undefined,
         expect.objectContaining({ isMine: false }),
@@ -257,10 +261,12 @@ describe('JSXConfirmationRepository', () => {
     });
 
     it('sets exchangeRate to undefined when rates client throws', async () => {
-      mockRatesClient.spotPrices.mockRejectedValue(new Error('API error'));
+      const ratesError = new Error('API error');
+      mockRatesClient.spotPrices.mockRejectedValue(ratesError);
 
       await repo.insertSendTransfer(mockAccount, mockPsbt, recipient, origin);
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(ratesError);
       expect(mockSnapClient.createInterface).toHaveBeenCalledWith(
         undefined,
         expect.objectContaining({ exchangeRate: undefined }),
@@ -428,10 +434,11 @@ describe('JSXConfirmationRepository', () => {
     });
 
     it('handles PSBT fee_amount throwing an error gracefully', async () => {
+      const feeError = new Error('Missing TxOut data');
       const psbtFeeError = mock<Psbt>({
         toString: () => 'psbt-fee-error',
         fee_amount: () => {
-          throw new Error('Missing TxOut data');
+          throw feeError;
         },
         unsigned_tx: mock<Transaction>({
           output: [],
@@ -440,6 +447,7 @@ describe('JSXConfirmationRepository', () => {
       });
       await repo.insertSignPsbt(mockAccount, psbtFeeError, origin, options);
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(feeError);
       expect(mockSnapClient.createInterface).toHaveBeenCalledWith(
         undefined,
         expect.objectContaining({ fee: undefined }),
@@ -476,10 +484,12 @@ describe('JSXConfirmationRepository', () => {
     });
 
     it('sets exchangeRate to undefined when rates client throws', async () => {
-      mockRatesClient.spotPrices.mockRejectedValue(new Error('API error'));
+      const ratesError = new Error('API error');
+      mockRatesClient.spotPrices.mockRejectedValue(ratesError);
 
       await repo.insertSignPsbt(mockAccount, mockSignPsbt, origin, options);
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(ratesError);
       expect(mockSnapClient.createInterface).toHaveBeenCalledWith(
         undefined,
         expect.objectContaining({ exchangeRate: undefined }),
@@ -487,12 +497,16 @@ describe('JSXConfirmationRepository', () => {
     });
 
     it('sets address to undefined when BdkAddress.from_script throws', async () => {
+      const scriptError = new Error('Unrecognized script');
       MockedBdkAddress.from_script.mockImplementation(() => {
-        throw new Error('Unrecognized script');
+        throw scriptError;
       });
 
       await repo.insertSignPsbt(mockAccount, mockSignPsbt, origin, options);
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(
+        scriptError,
+      );
       expect(mockSnapClient.createInterface).toHaveBeenCalledWith(
         undefined,
         expect.objectContaining({

--- a/packages/snap/src/store/JSXConfirmationRepository.tsx
+++ b/packages/snap/src/store/JSXConfirmationRepository.tsx
@@ -95,7 +95,8 @@ export class JSXConfirmationRepository implements ConfirmationRepository {
         account.network,
       ).script_pubkey;
       isMine = account.isMine(recipientScript);
-    } catch {
+    } catch (error) {
+      await this.#snapClient.emitTrackingError(error as Error);
       isMine = false;
     }
 
@@ -141,7 +142,8 @@ export class JSXConfirmationRepository implements ConfirmationRepository {
       if (feeAmount) {
         fee = feeAmount.to_sat().toString();
       }
-    } catch {
+    } catch (error) {
+      await this.#snapClient.emitTrackingError(error as Error);
       fee = undefined;
     }
 
@@ -157,7 +159,8 @@ export class JSXConfirmationRepository implements ConfirmationRepository {
             txout.script_pubkey,
             account.network,
           ).toString();
-        } catch {
+        } catch (error) {
+          await this.#snapClient.emitTrackingError(error as Error);
           address = undefined;
         }
       }
@@ -220,6 +223,8 @@ export class JSXConfirmationRepository implements ConfirmationRepository {
         currency: currency.toUpperCase(),
       };
     } catch (error) {
+      await this.#snapClient.emitTrackingError(error as Error);
+
       // Exchange rates are optional display information - don't fail if unavailable
       this.#logger.warn(
         `Failed to fetch spot price for currency ${currency}`,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Adds error tracking to `JSXConfirmationRepository` fallback paths that previously swallowed exceptions and continued silently. Adjusts test cases to reflect tracking.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes [WPN-1452](https://consensyssoftware.atlassian.net/browse/WPN-1452)

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


[WPN-1452]: https://consensyssoftware.atlassian.net/browse/WPN-1452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes on optional display/fallback paths; confirmation flow and error handling behavior for users are unchanged.
> 
> **Overview**
> **`JSXConfirmationRepository`** now reports errors that were previously caught and ignored while building send/PSBT confirmation UI, via **`SnapClient.emitTrackingError`**.
> 
> Tracking was added when recipient address parsing fails (`isMine` stays false), PSBT **`fee_amount`** or output **`from_script`** resolution fails, and **`#getExchangeRate`** fails after the existing warn log—user-facing behavior (undefined fee/rate/address, confirmations still proceed) is unchanged.
> 
> Tests assert **`emitTrackingError`** is invoked with the same **`Error`** instances in those fallback scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c592ccdb70d859220457d55ee211db3f1556d0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->