### PR TITLE
fix: handle non-url origins

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Display known non-URL origins in confirmations without throwing on invalid origin values ([#634](https://github.com/MetaMask/snap-bitcoin-wallet/pull/634))
+
 ## [1.14.1]
 
 ### Fixed

--- a/packages/snap/src/infra/jsx/format.test.ts
+++ b/packages/snap/src/infra/jsx/format.test.ts
@@ -1,0 +1,50 @@
+import { displayOrigin } from './format';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+jest.mock('@metamask/bitcoindevkit', () => ({
+  Amount: {
+    from_sat: jest.fn(),
+  },
+  BdkErrorCode: {},
+}));
+/* eslint-enable @typescript-eslint/naming-convention */
+
+describe('displayOrigin', () => {
+  it('returns the known label for the internal "metamask" origin', () => {
+    expect(displayOrigin('metamask')).toBe('MetaMask');
+  });
+
+  it('returns the known label for the "wallet-connect" origin', () => {
+    expect(displayOrigin('wallet-connect')).toBe('WalletConnect');
+  });
+
+  it('matches known origins case-insensitively', () => {
+    expect(displayOrigin('MetaMask')).toBe('MetaMask');
+    expect(displayOrigin('Wallet-Connect')).toBe('WalletConnect');
+  });
+
+  it('returns the hostname for a valid https URL', () => {
+    expect(displayOrigin('https://app.uniswap.org')).toBe('app.uniswap.org');
+  });
+
+  it('returns the hostname for a valid http URL', () => {
+    expect(displayOrigin('http://localhost:8080')).toBe('localhost');
+  });
+
+  it('returns an empty string for a non-http(s) URL', () => {
+    expect(displayOrigin('ftp://example.com')).toBe('');
+  });
+
+  it('returns an empty string for a WalletConnect channelId', () => {
+    expect(
+      displayOrigin(
+        'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2',
+      ),
+    ).toBe('');
+  });
+
+  it('returns an empty string for an invalid origin', () => {
+    expect(displayOrigin('not a url')).toBe('');
+    expect(displayOrigin('')).toBe('');
+  });
+});

--- a/packages/snap/src/infra/jsx/format.ts
+++ b/packages/snap/src/infra/jsx/format.ts
@@ -89,6 +89,7 @@ export const displayOrigin = (origin: string): string => {
       ? url.hostname
       : '';
   } catch {
+    console.log('[format] - displayOrigin - failed to parse origin', origin);
     return '';
   }
 };

--- a/packages/snap/src/infra/jsx/format.ts
+++ b/packages/snap/src/infra/jsx/format.ts
@@ -68,8 +68,29 @@ export const errorCodeToLabel = (code: number): string => {
   return raw.charAt(0).toLowerCase() + raw.slice(1);
 };
 
+/**
+ * Known origins mapped to their human-readable labels. Keys are lowercased so
+ * lookups can be performed case-insensitively against the raw origin.
+ */
+const KNOWN_ORIGIN_LABELS: Record<string, string> = {
+  metamask: 'MetaMask',
+  'wallet-connect': 'WalletConnect',
+};
+
 export const displayOrigin = (origin: string): string => {
-  return new URL(origin).hostname;
+  const knownLabel = KNOWN_ORIGIN_LABELS[origin.toLowerCase()];
+  if (knownLabel) {
+    return knownLabel;
+  }
+
+  try {
+    const url = new URL(origin);
+    return url.protocol === 'http:' || url.protocol === 'https:'
+      ? url.hostname
+      : '';
+  } catch {
+    return '';
+  }
 };
 
 export const displayCaip10 = (


### PR DESCRIPTION
## Explanation

This PR updates the Bitcoin Snap origin formatting helper to handle non-URL origins such as the stable `wallet-connect` origin used by MetaMask Mobile WalletConnect multichain requests.

Valid HTTP(S) URL origins continue to be displayed as hostnames. Known non-URL origins are displayed with friendly labels, currently `MetaMask` and `WalletConnect`. Unknown invalid origins, including WalletConnect channel IDs, now format to an empty string so confirmation UI can avoid showing meaningless identifiers.

Tests were added for known origins, URL origins, non-http URLs, WalletConnect channel IDs, and invalid origin strings.

## References

* Related to MetaMask Mobile PR: https://github.com/MetaMask/metamask-mobile/pull/32339
* Related Tron Snap PR: https://github.com/MetaMask/snap-tron-wallet/pull/340

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
  - N/A - no package changelog update needed for this internal behavior fix.
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
  - N/A - this does not introduce a breaking API change.

## Validation

```bash
yarn workspace @metamask/bitcoin-wallet-snap jest packages/snap/src/infra/jsx/format.test.ts --runInBand --coverage=false
```

Result: 1 test suite passed, 8 tests passed.

```bash
yarn eslint packages/snap/src/infra/jsx/format.ts packages/snap/src/infra/jsx/format.test.ts
```

Result: passed.

Note: `yarn lint:eslint` currently fails on existing import-order issues outside this diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display helper change with defensive parsing; no auth, signing, or transaction logic changes.
> 
> **Overview**
> **`displayOrigin`** no longer assumes every origin is a parseable URL. Confirmation flows (e.g. sign message) can show stable non-URL origins from WalletConnect multichain without crashing.
> 
> Known string origins **`metamask`** and **`wallet-connect`** map to **MetaMask** and **WalletConnect** (case-insensitive). Valid **http/https** origins still show the hostname. Unparseable values, non-http(s) schemes, WalletConnect channel IDs, and other unknown strings return an **empty string** instead of throwing. Unit tests cover these cases; the snap changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6f831e20ccabe75a22802ad07252f497a5c386b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->