### PR TITLE
chore: track error batch

### DIFF
--- a/packages/snap/src/handlers/AssetsHandler.test.ts
+++ b/packages/snap/src/handlers/AssetsHandler.test.ts
@@ -7,12 +7,13 @@ import { mock } from 'jest-mock-extended';
 import type { AssetsUseCases } from '../use-cases';
 import { AssetsHandler } from './AssetsHandler';
 import { Caip19Asset } from './caip';
-import type { Logger, SpotPrice } from '../entities';
+import type { Logger, SnapClient, SpotPrice } from '../entities';
 
 describe('AssetsHandler', () => {
   const mockAssetsUseCases = mock<AssetsUseCases>();
   const mockLogger = mock<Logger>();
   const expirationInterval = 60;
+  const mockSnapClient = mock<SnapClient>();
 
   let handler: AssetsHandler;
 
@@ -21,6 +22,7 @@ describe('AssetsHandler', () => {
       mockAssetsUseCases,
       expirationInterval,
       mockLogger,
+      mockSnapClient,
     );
   });
 
@@ -146,7 +148,7 @@ describe('AssetsHandler', () => {
       expect(result?.historicalPrice.intervals).toStrictEqual(mockIntervals);
     });
 
-    it('returns null and logs warning when getPriceIntervals fails', async () => {
+    it('returns null, tracks the error, and logs warning when getPriceIntervals fails', async () => {
       const error = new Error('getPriceIntervals failed');
       mockAssetsUseCases.getPriceIntervals.mockRejectedValue(error);
 
@@ -155,6 +157,7 @@ describe('AssetsHandler', () => {
         Caip19Asset.Testnet,
       );
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(error);
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'Failed to fetch historical prices from %s to %s. Error: %s',
         Caip19Asset.Bitcoin,

--- a/packages/snap/src/handlers/AssetsHandler.ts
+++ b/packages/snap/src/handlers/AssetsHandler.ts
@@ -13,7 +13,7 @@ import type {
 import { CaipAssetTypeStruct } from '@metamask/utils';
 import { assert } from 'superstruct';
 
-import type { Logger } from '../entities';
+import type { Logger, SnapClient } from '../entities';
 import type { AssetsUseCases } from '../use-cases';
 import { Caip19Asset } from './caip';
 import { networkToIcon } from './icons';
@@ -25,14 +25,18 @@ export class AssetsHandler {
 
   readonly #logger: Logger;
 
+  readonly #snapClient: SnapClient;
+
   constructor(
     assets: AssetsUseCases,
     expirationInterval: number,
     logger: Logger,
+    snapClient: SnapClient,
   ) {
     this.#assetsUseCases = assets;
     this.#expirationInterval = expirationInterval;
     this.#logger = logger;
+    this.#snapClient = snapClient;
   }
 
   async lookup(): Promise<OnAssetsLookupResponse> {
@@ -163,6 +167,8 @@ export class AssetsHandler {
         },
       };
     } catch (error) {
+      await this.#snapClient.emitTrackingError(error as Error);
+
       this.#logger.warn(
         'Failed to fetch historical prices from %s to %s. Error: %s',
         from,

--- a/packages/snap/src/handlers/CronHandler.test.ts
+++ b/packages/snap/src/handlers/CronHandler.test.ts
@@ -3,7 +3,11 @@ import { getSelectedAccounts } from '@metamask/keyring-snap-sdk';
 import type { SnapsProvider, JsonRpcRequest } from '@metamask/snaps-sdk';
 import { mock } from 'jest-mock-extended';
 
-import type { BitcoinAccount, SnapClient, SyncResult } from '../entities';
+import {
+  type BitcoinAccount,
+  type SnapClient,
+  type SyncResult,
+} from '../entities';
 import type { SendFlowUseCases, AccountUseCases } from '../use-cases';
 import { CronHandler, CronMethod } from './CronHandler';
 
@@ -263,15 +267,24 @@ describe('CronHandler', () => {
         account: mockAccount1,
         transactionsToNotify: [],
       };
+      const syncError = new Error('scan failed');
       mockAccountUseCases.list.mockResolvedValue(mockAccounts);
       mockAccountUseCases.synchronize
         .mockResolvedValueOnce(mockResult)
-        .mockRejectedValueOnce(new Error('scan failed'));
+        .mockRejectedValueOnce(syncError);
 
       const result = await handler.route(request);
 
       expect(result).toBeUndefined();
       expect(mockAccountUseCases.synchronize).toHaveBeenCalledTimes(2);
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'SynchronizationError',
+          message: 'Failed to synchronize 1 selected accounts',
+          cause: syncError,
+        }),
+      );
+
       // Should emit for successful account only
       expect(
         mockSnapClient.emitAccountBalancesUpdatedEvent,

--- a/packages/snap/src/handlers/CronHandler.ts
+++ b/packages/snap/src/handlers/CronHandler.ts
@@ -142,6 +142,20 @@ export class CronHandler {
       )
       .map((result) => result.value);
 
+    const rejectedResults = results.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+
+    if (rejectedResults.length > 0) {
+      await this.#snapClient.emitTrackingError(
+        new SynchronizationError(
+          `Failed to synchronize ${rejectedResults.length} selected accounts`,
+          undefined,
+          rejectedResults[0]?.reason,
+        ),
+      );
+    }
+
     await this.#emitSyncEvents(successfulResults);
   }
 

--- a/packages/snap/src/handlers/KeyringHandler.test.ts
+++ b/packages/snap/src/handlers/KeyringHandler.test.ts
@@ -1270,7 +1270,7 @@ describe('KeyringHandler', () => {
       expect(result).toBeNull();
     });
 
-    it('returns null when scope validation fails', async () => {
+    it('returns null and tracks the error when scope validation fails', async () => {
       const request = {
         id: '1',
         jsonrpc: '2.0' as const,
@@ -1280,9 +1280,10 @@ describe('KeyringHandler', () => {
           psbt: 'psbt',
         },
       };
+      const error = new Error('Invalid scope');
 
       jest.mocked(assert).mockImplementationOnce(() => {
-        throw new Error('Invalid scope');
+        throw error;
       });
 
       const result = await handler.resolveAccountAddress(
@@ -1290,6 +1291,7 @@ describe('KeyringHandler', () => {
         request,
       );
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(error);
       expect(result).toBeNull();
     });
 

--- a/packages/snap/src/handlers/KeyringHandler.ts
+++ b/packages/snap/src/handlers/KeyringHandler.ts
@@ -534,6 +534,8 @@ export class KeyringHandler implements Keyring {
 
       return { address: `${scope}:${addressToValidate}` };
     } catch (error: unknown) {
+      await this.#snapClient.emitTrackingError(error as Error);
+
       this.#logger.error({ error }, 'Error resolving account address');
       return null;
     }

--- a/packages/snap/src/handlers/RpcHandler.ts
+++ b/packages/snap/src/handlers/RpcHandler.ts
@@ -231,6 +231,8 @@ export class RpcHandler {
 
       return validateAddress(value, bitcoinAccount.network, this.#logger);
     } catch (error) {
+      // We do not track this error as it is a user input.
+
       this.#logger.error(
         `Invalid account. Error: %s`,
         (error as CodifiedError).message,
@@ -260,6 +262,8 @@ export class RpcHandler {
 
       return balanceValidation.valid ? NO_ERRORS_RESPONSE : balanceValidation;
     } catch (error) {
+      // We do not track this error as it is a user input.
+
       this.#logger.error(
         'An error occurred: %s',
         (error as CodifiedError).message,

--- a/packages/snap/src/handlers/mappings.ts
+++ b/packages/snap/src/handlers/mappings.ts
@@ -111,6 +111,7 @@ const mapToAssetMovement = (
       asset: mapToAmount(output.value, network),
     };
   } catch {
+    // We do not track this error as non-address scripts are expected here
     return null;
   }
 };
@@ -302,6 +303,7 @@ export function mapToUtxo(utxo: LocalOutput, network: Network): Utxo {
   try {
     address = Address.from_script(utxo.txout.script_pubkey, network);
   } catch {
+    // We do not track this error as the address field is explicitly optional in Utxo
     address = undefined;
   }
 

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -113,6 +113,7 @@ const assetsHandler = new AssetsHandler(
   assetsUseCases,
   Config.conversionsExpirationInterval,
   logger,
+  snapClient,
 );
 
 export const onCronjob: OnCronjobHandler = async ({ request }) =>

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -82,6 +82,7 @@ const assetsUseCases = new AssetsUseCases(
   logger,
   assetRatesClient,
   new InMemoryCache(),
+  snapClient,
 );
 const confirmationUseCases = new ConfirmationUseCases(logger, snapClient);
 

--- a/packages/snap/src/use-cases/AssetsUseCases.test.ts
+++ b/packages/snap/src/use-cases/AssetsUseCases.test.ts
@@ -1,7 +1,12 @@
 import type { HistoricalPriceValue } from '@metamask/snaps-sdk';
 import { mock } from 'jest-mock-extended';
 
-import type { AssetRatesClient, Logger, SpotPrice } from '../entities';
+import type {
+  AssetRatesClient,
+  Logger,
+  SnapClient,
+  SpotPrice,
+} from '../entities';
 import { AssetsUseCases } from './AssetsUseCases';
 import { Caip19Asset } from '../handlers/caip';
 import type { ICache, Serializable } from '../store/ICache';
@@ -10,8 +15,14 @@ describe('AssetsUseCases', () => {
   const mockLogger = mock<Logger>();
   const mockAssetRates = mock<AssetRatesClient>();
   const mockCache = mock<ICache<Serializable>>();
+  const mockSnapClient = mock<SnapClient>();
 
-  const useCases = new AssetsUseCases(mockLogger, mockAssetRates, mockCache);
+  const useCases = new AssetsUseCases(
+    mockLogger,
+    mockAssetRates,
+    mockCache,
+    mockSnapClient,
+  );
 
   describe('getBtcRates', () => {
     it('returns rate for the known assets and null for unknown', async () => {
@@ -65,6 +76,8 @@ describe('AssetsUseCases', () => {
 
       const result = await useCases.getRates([Caip19Asset.Testnet]);
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledTimes(1);
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(error);
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'Failed to fetch spot price for ticker btc',
         error,
@@ -168,6 +181,8 @@ describe('AssetsUseCases', () => {
 
       const result = await useCases.getPriceIntervals('swift:0/iso4217:USD');
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledTimes(6);
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(error);
       expect(mockLogger.warn).toHaveBeenCalledTimes(6);
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'Failed to fetch historical prices for period P1D',

--- a/packages/snap/src/use-cases/AssetsUseCases.ts
+++ b/packages/snap/src/use-cases/AssetsUseCases.ts
@@ -7,6 +7,7 @@ import type {
   AssetRate,
   AssetRatesClient,
   Logger,
+  SnapClient,
   SpotPrice,
   TimePeriod,
 } from '../entities';
@@ -19,14 +20,18 @@ export class AssetsUseCases {
 
   readonly #cache: ICache<Serializable>;
 
+  readonly #snapClient: SnapClient;
+
   constructor(
     logger: Logger,
     assetRates: AssetRatesClient,
     cache: ICache<Serializable>,
+    snapClient: SnapClient,
   ) {
     this.#logger = logger;
     this.#assetRates = assetRates;
     this.#cache = cache;
+    this.#snapClient = snapClient;
   }
 
   async getRates(assets: CaipAssetType[]): Promise<AssetRate[]> {
@@ -74,7 +79,9 @@ export class AssetsUseCases {
               (asset) => [asset, spotPrices] as AssetRate,
             );
           })
-          .catch((error) => {
+          .catch(async (error) => {
+            await this.#snapClient.emitTrackingError(error as Error);
+
             this.#logger.warn(
               `Failed to fetch spot price for ticker ${ticker}`,
               error,
@@ -123,7 +130,9 @@ export class AssetsUseCases {
       this.#assetRates
         .historicalPrices(timePeriod, vsCurrency)
         .then((prices) => ({ timePeriod, prices }))
-        .catch((error) => {
+        .catch(async (error) => {
+          await this.#snapClient.emitTrackingError(error as Error);
+
           this.#logger.warn(
             `Failed to fetch historical prices for period ${timePeriod}`,
             error,

--- a/packages/snap/src/use-cases/SendFlowUseCases.test.ts
+++ b/packages/snap/src/use-cases/SendFlowUseCases.test.ts
@@ -359,6 +359,7 @@ describe('SendFlowUseCases', () => {
         mockContext,
       );
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(buildError);
       expect(mockSendFlowRepository.updateForm).toHaveBeenCalledWith(
         'interface-id',
         expect.objectContaining({
@@ -810,12 +811,12 @@ describe('SendFlowUseCases', () => {
     });
 
     it('schedules next event if fetching rates fail', async () => {
-      mockChain.getFeeEstimates.mockRejectedValueOnce(
-        new Error('getFeeEstimates'),
-      );
+      const error = new Error('getFeeEstimates');
+      mockChain.getFeeEstimates.mockRejectedValueOnce(error);
 
       await useCases.refresh('interface-id');
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(error);
       expect(mockSnapClient.scheduleBackgroundEvent).toHaveBeenCalled();
       expect(mockSendFlowRepository.updateForm).toHaveBeenCalledWith(
         'interface-id',
@@ -884,6 +885,7 @@ describe('SendFlowUseCases', () => {
 
       await useCases.refresh('interface-id');
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(error);
       expect(mockSnapClient.scheduleBackgroundEvent).toHaveBeenCalled();
       expect(mockSendFlowRepository.updateForm).toHaveBeenCalledWith(
         'interface-id',
@@ -903,12 +905,12 @@ describe('SendFlowUseCases', () => {
     });
 
     it('returns undefined when context is not found', async () => {
-      mockSendFlowRepository.getContext.mockRejectedValue(
-        new Error('Missing context'),
-      );
+      const error = new Error('Missing context');
+      mockSendFlowRepository.getContext.mockRejectedValue(error);
 
       const result = await useCases.refresh('interface-id');
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(error);
       expect(result).toBeUndefined();
     });
   });
@@ -1006,12 +1008,14 @@ describe('SendFlowUseCases', () => {
     });
 
     it('defaults isMine to false when the recipient address fails to parse', async () => {
+      const error = new Error('Invalid address');
       (Address.from_string as jest.Mock).mockImplementation(() => {
-        throw new Error('Invalid address');
+        throw error;
       });
 
       await useCases.confirmSendFlow(mockAccount, amount, toAddress);
 
+      expect(mockSnapClient.emitTrackingError).toHaveBeenCalledWith(error);
       expect(mockSendFlowRepository.insertConfirmSendForm).toHaveBeenCalledWith(
         expect.objectContaining({ isMine: false }),
       );

--- a/packages/snap/src/use-cases/SendFlowUseCases.ts
+++ b/packages/snap/src/use-cases/SendFlowUseCases.ts
@@ -119,7 +119,8 @@ export class SendFlowUseCases {
         account.network,
       ).script_pubkey;
       isMine = account.isMine(recipientScript);
-    } catch {
+    } catch (error) {
+      await this.#snapClient.emitTrackingError(error as Error);
       isMine = false;
     }
 
@@ -350,6 +351,8 @@ export class SendFlowUseCases {
           currency: currency.toUpperCase(),
         };
       } catch (error) {
+        await this.#snapClient.emitTrackingError(error as Error);
+
         // exchange rates are optional display information - don't fail if unavailable
         this.#logger.warn(
           `Failed to fetch exchange rate for ${currency}. Error: %s`,
@@ -378,6 +381,8 @@ export class SendFlowUseCases {
       ).toString();
       updatedContext = await this.#computeFee(updatedContext);
     } catch (error) {
+      // We do not track this error as it is a user input.
+
       this.#logger.error(
         `Invalid recipient. Error: %s`,
         (error as CodifiedError).message,
@@ -419,6 +424,8 @@ export class SendFlowUseCases {
       updatedContext.amount = amount.to_sat().toString();
       updatedContext = await this.#computeFee(updatedContext);
     } catch (error) {
+      // We do not track this error as it is a user input.
+
       this.#logger.error(
         `Invalid amount. Error: %s`,
         (error as CodifiedError).message,
@@ -475,6 +482,8 @@ export class SendFlowUseCases {
 
         return this.#sendFlowRepository.updateReview(id, reviewContext);
       } catch (error) {
+        await this.#snapClient.emitTrackingError(error as Error);
+
         this.#logger.error(
           `Failed to build PSBT on Confirm. Error: %s`,
           (error as CodifiedError).message,
@@ -528,6 +537,8 @@ export class SendFlowUseCases {
       const context = await this.#sendFlowRepository.getContext(id);
       return this.#refreshRates(id, context);
     } catch (error) {
+      await this.#snapClient.emitTrackingError(error as Error);
+
       // We do not throw as this is probably due to a scheduled event executing after the interface has been removed.
       this.#logger.debug('Context not found in send flow:', id, error);
       return undefined;
@@ -553,6 +564,8 @@ export class SendFlowUseCases {
       );
       updatedContext = await this.#computeFee(updatedContext);
     } catch (error) {
+      await this.#snapClient.emitTrackingError(error as Error);
+
       // We do not throw so we can reschedule. Previous fetched values or fallbacks will be used.
       this.#logger.warn(
         `Failed to fetch rates in send form: %s. Error: %s`,
@@ -603,6 +616,8 @@ export class SendFlowUseCases {
         const psbt = builder.addRecipient(amount, recipient).finish();
         return { ...context, fee: psbt.fee().to_sat().toString(), balance };
       } catch (error) {
+        // We do not track this error as it is a form validation feedback.
+
         this.#logger.error(
           `Failed to build PSBT. Error: %s`,
           (error as CodifiedError).message,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Adds `emitTrackingError` coverage for operational failures across `AssetsUseCases`, `SendFlowUseCases`, and several handlers (`Assets`, `Cron`, `Keyring`, and `Rpc`), and updates tests accordingly.
It also documents an intentional exception in `mappings.ts`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes [WPN-1453](https://consensyssoftware.atlassian.net/browse/WPN-1453), [WPN-1454](https://consensyssoftware.atlassian.net/browse/WPN-1454), [WPN-1457](https://consensyssoftware.atlassian.net/browse/WPN-1457), [WPN-1459](https://consensyssoftware.atlassian.net/browse/WPN-1459)

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


[WPN-1453]: https://consensyssoftware.atlassian.net/browse/WPN-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds observability only; existing catch-and-degrade behavior is preserved, with explicit exclusions for user-input validation to avoid noisy telemetry.
> 
> **Overview**
> Wires **`SnapClient.emitTrackingError`** into operational failure paths across the Bitcoin snap so rate fetches, sync, send-flow, and keyring resolution issues surface in product telemetry without changing user-visible outcomes.
> 
> **Assets:** `AssetsUseCases` now takes `SnapClient` and reports spot/historical price API failures; `AssetsHandler` reports when historical price lookup fails after the use case throws.
> 
> **Cron:** `syncSelectedAccounts` emits a **`SynchronizationError`** (with the first rejection as cause) when some selected-account syncs fail, while still emitting events for successful accounts.
> 
> **Send flow:** `SendFlowUseCases` tracks failures for exchange-rate fetch, PSBT build on confirm, background rate refresh, missing send-form context on refresh, and recipient `isMine` parsing in `confirmSendFlow`. Comments mark paths left untracked as user input or form validation feedback (recipient/amount handlers, `#computeFee`, Rpc address/amount validation).
> 
> **Keyring:** `resolveAccountAddress` tracks errors before returning null.
> 
> **Mappings:** Comments document why script-to-address conversion failures are not tracked (expected non-address scripts, optional UTXO address field).
> 
> Tests and `index.ts` wiring updated for the new `SnapClient` dependency on `AssetsUseCases` / `AssetsHandler`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c9a37e7fe67b9c43cce2924a91274ee4f9a911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->