### PR TITLE
Reapply "fix: handle non-url origins (#634)" (#637)

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.14.2]
 
+### Fixed
+
 - Accept the optional `options` object in `signAndSendTransaction` request params to fix broken BTC bridging ([#636](https://github.com/MetaMask/snap-bitcoin-wallet/pull/636))
 
 ## [1.14.1]

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Display known non-URL origins in confirmations without throwing on invalid origin values ([#634](https://github.com/MetaMask/snap-bitcoin-wallet/pull/634))
+- Display known non-URL origins in confirmations without throwing on invalid origin values ([#640](https://github.com/MetaMask/snap-bitcoin-wallet/pull/640))
 
 ## [1.14.2]
 

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.14.2]
-
 ### Fixed
 
 - Display known non-URL origins in confirmations without throwing on invalid origin values ([#634](https://github.com/MetaMask/snap-bitcoin-wallet/pull/634))
+
+## [1.14.2]
+
 - Accept the optional `options` object in `signAndSendTransaction` request params to fix broken BTC bridging ([#636](https://github.com/MetaMask/snap-bitcoin-wallet/pull/636))
 
 ## [1.14.1]

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Display known non-URL origins in confirmations without throwing on invalid origin values ([#634](https://github.com/MetaMask/snap-bitcoin-wallet/pull/634))
 - Accept the optional `options` object in `signAndSendTransaction` request params to fix broken BTC bridging ([#636](https://github.com/MetaMask/snap-bitcoin-wallet/pull/636))
 
 ## [1.14.1]

--- a/packages/snap/src/infra/jsx/format.test.ts
+++ b/packages/snap/src/infra/jsx/format.test.ts
@@ -1,0 +1,50 @@
+import { displayOrigin } from './format';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+jest.mock('@metamask/bitcoindevkit', () => ({
+  Amount: {
+    from_sat: jest.fn(),
+  },
+  BdkErrorCode: {},
+}));
+/* eslint-enable @typescript-eslint/naming-convention */
+
+describe('displayOrigin', () => {
+  it('returns the known label for the internal "metamask" origin', () => {
+    expect(displayOrigin('metamask')).toBe('MetaMask');
+  });
+
+  it('returns the known label for the "wallet-connect" origin', () => {
+    expect(displayOrigin('wallet-connect')).toBe('WalletConnect');
+  });
+
+  it('matches known origins case-insensitively', () => {
+    expect(displayOrigin('MetaMask')).toBe('MetaMask');
+    expect(displayOrigin('Wallet-Connect')).toBe('WalletConnect');
+  });
+
+  it('returns the hostname for a valid https URL', () => {
+    expect(displayOrigin('https://app.uniswap.org')).toBe('app.uniswap.org');
+  });
+
+  it('returns the hostname for a valid http URL', () => {
+    expect(displayOrigin('http://localhost:8080')).toBe('localhost');
+  });
+
+  it('returns an empty string for a non-http(s) URL', () => {
+    expect(displayOrigin('ftp://example.com')).toBe('');
+  });
+
+  it('returns an empty string for a WalletConnect channelId', () => {
+    expect(
+      displayOrigin(
+        'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2',
+      ),
+    ).toBe('');
+  });
+
+  it('returns an empty string for an invalid origin', () => {
+    expect(displayOrigin('not a url')).toBe('');
+    expect(displayOrigin('')).toBe('');
+  });
+});

--- a/packages/snap/src/infra/jsx/format.ts
+++ b/packages/snap/src/infra/jsx/format.ts
@@ -68,8 +68,30 @@ export const errorCodeToLabel = (code: number): string => {
   return raw.charAt(0).toLowerCase() + raw.slice(1);
 };
 
+/**
+ * Known origins mapped to their human-readable labels. Keys are lowercased so
+ * lookups can be performed case-insensitively against the raw origin.
+ */
+const KNOWN_ORIGIN_LABELS: Record<string, string> = {
+  metamask: 'MetaMask',
+  'wallet-connect': 'WalletConnect',
+};
+
 export const displayOrigin = (origin: string): string => {
-  return new URL(origin).hostname;
+  const knownLabel = KNOWN_ORIGIN_LABELS[origin.toLowerCase()];
+  if (knownLabel) {
+    return knownLabel;
+  }
+
+  try {
+    const url = new URL(origin);
+    return url.protocol === 'http:' || url.protocol === 'https:'
+      ? url.hostname
+      : '';
+  } catch {
+    console.log('[format] - displayOrigin - failed to parse origin', origin);
+    return '';
+  }
 };
 
 export const displayCaip10 = (


### PR DESCRIPTION
This reverts commit e188fb360a02fd3c04e2530f3196147bf9d49c09.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, defensive change to JSX formatting for confirmation display only; no auth, signing, or transaction logic touched.
> 
> **Overview**
> **`displayOrigin`** no longer assumes every origin is a parseable URL. It now maps known internal origins (`metamask`, `wallet-connect`) to friendly labels (case-insensitive), still shows the hostname for valid `http`/`https` URLs, and returns an empty string instead of throwing when parsing fails or the scheme is not http(s).
> 
> Unit tests cover the new behavior, and the snap changelog records the fix for confirmation UIs that call this helper (e.g. sign-message flows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d5f1820c004b905af46ad19bb4bf6b5982f735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->